### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -1,7 +1,7 @@
 'use strict'
 
 var caseless = require('caseless')
-  , uuid = require('node-uuid')
+  , uuid = require('uuid')
   , helpers = require('./helpers')
 
 var md5 = helpers.md5

--- a/lib/multipart.js
+++ b/lib/multipart.js
@@ -1,6 +1,6 @@
 'use strict'
 
-var uuid = require('node-uuid')
+var uuid = require('uuid')
   , CombinedStream = require('combined-stream')
   , isstream = require('isstream')
 

--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -3,7 +3,7 @@
 var url = require('url')
   , qs = require('qs')
   , caseless = require('caseless')
-  , uuid = require('node-uuid')
+  , uuid = require('uuid')
   , oauth = require('oauth-sign')
   , crypto = require('crypto')
 

--- a/package.json
+++ b/package.json
@@ -32,12 +32,12 @@
     "isstream": "~0.1.2",
     "json-stringify-safe": "~5.0.1",
     "mime-types": "~2.1.7",
-    "node-uuid": "~1.4.7",
     "oauth-sign": "~0.8.1",
     "qs": "~6.3.0",
     "stringstream": "~0.0.4",
     "tough-cookie": "~2.3.0",
-    "tunnel-agent": "~0.4.1"
+    "tunnel-agent": "~0.4.1",
+    "uuid": "^3.0.0"
   },
   "scripts": {
     "test": "npm run lint && npm run test-ci && npm run test-browser",


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.