### PR TITLE
Bumped tough-cookie to v2.3.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "safe-buffer": "^5.0.1",
     "stream-length": "^1.0.2",
     "stringstream": "~0.0.4",
-    "tough-cookie": "~2.3.0",
+    "tough-cookie": "~2.3.3",
     "tunnel-agent": "^0.6.0",
     "uuid": "^3.0.0"
   },


### PR DESCRIPTION
Fixes https://nodesecurity.io/advisories/525