### PR TITLE
 Allow sending request body with HEAD method

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,9 +16,6 @@
 
 var extend = require('extend')
 var cookies = require('./lib/cookies')
-var helpers = require('./lib/helpers')
-
-var paramsHaveRequestBody = helpers.paramsHaveRequestBody
 
 // organize params for patch, post, put, head, del
 function initParams (uri, options, callback) {
@@ -45,10 +42,6 @@ function request (uri, options, callback) {
   }
 
   var params = initParams(uri, options, callback)
-
-  if (params.method === 'HEAD' && paramsHaveRequestBody(params)) {
-    throw new Error('HTTP HEAD requests MUST NOT include a request body.')
-  }
 
   return new request.Request(params)
 }

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -8,14 +8,16 @@ var defer = typeof setImmediate === 'undefined'
   ? process.nextTick
   : setImmediate
 
-function paramsHaveRequestBody (params) {
-  return (
-    params.body ||
-    params.requestBodyStream ||
-    (params.json && typeof params.json !== 'boolean') ||
-    params.multipart
-  )
-}
+// Reference: https://github.com/postmanlabs/postman-request/pull/23
+//
+// function paramsHaveRequestBody (params) {
+//   return (
+//     params.body ||
+//     params.requestBodyStream ||
+//     (params.json && typeof params.json !== 'boolean') ||
+//     params.multipart
+//   )
+// }
 
 function safeStringify (obj, replacer) {
   var ret
@@ -56,7 +58,6 @@ function version () {
   }
 }
 
-exports.paramsHaveRequestBody = paramsHaveRequestBody
 exports.safeStringify = safeStringify
 exports.md5 = md5
 exports.isReadStream = isReadStream

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "util",
     "utility"
   ],
-  "version": "2.87.1-postman.1-beta.1",
+  "version": "2.88.1-postman.1-beta.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/postmanlabs/postman-request.git"

--- a/tests/test-defaults.js
+++ b/tests/test-defaults.js
@@ -230,7 +230,7 @@ tape('recursive defaults requester', function (t) {
 })
 
 tape('test custom request handler function', function (t) {
-  t.plan(3)
+  t.plan(6)
 
   var requestWithCustomHandler = request.defaults({
     headers: { foo: 'bar' },
@@ -241,11 +241,13 @@ tape('test custom request handler function', function (t) {
     return request(params.uri, params, params.callback)
   })
 
-  t.throws(function () {
-    requestWithCustomHandler.head(s.url + '/', function (e, r, b) {
-      throw new Error('We should never get here')
-    })
-  }, /HTTP HEAD requests MUST NOT include a request body/)
+  requestWithCustomHandler.head(s.url + '/', function (e, r, b) {
+    t.equal(r.request.method, 'HEAD')
+    t.equal(r.request.body, 'TESTING!')
+    // body not parsed by Node's http-parser
+    t.equal(r.body, '')
+    t.equal(b, '')
+  })
 
   requestWithCustomHandler.get(s.url + '/', function (e, r, b) {
     b = JSON.parse(b)

--- a/tests/test-errors.js
+++ b/tests/test-errors.js
@@ -87,22 +87,3 @@ tape('multipart without body 2', function (t) {
   }, /^Error: Body attribute missing in multipart\.$/)
   t.end()
 })
-
-tape('head method with a body', function (t) {
-  t.throws(function () {
-    request(local, {
-      method: 'HEAD',
-      body: 'foo'
-    })
-  }, /HTTP HEAD requests MUST NOT include a request body/)
-  t.end()
-})
-
-tape('head method with a body 2', function (t) {
-  t.throws(function () {
-    request.head(local, {
-      body: 'foo'
-    })
-  }, /HTTP HEAD requests MUST NOT include a request body/)
-  t.end()
-})


### PR DESCRIPTION
## PR Checklist:
- [x] I have run `npm test` locally and all tests are passing.
- [x] I have added/updated tests for any new behavior.
       <!-- Request is a complex project, there are VERY FEW exceptions
               where a new test is not required for new behavior. -->
- [x] If this is a significant change, an issue has already been created where the problem / solution was discussed: N/A
       <!-- If you'd like to suggest a significant change to request,
               please create an issue to discuss those changes and gather
               feedback BEFORE submitting your PR. -->


## PR Description
Removes restriction of sending request body using HTTP `HEAD` method.
