### PR TITLE
Respect form-data fields ordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This is a fork of the excellent `request` module, which is used inside Postman R
 - Allowed sending request body with HEAD method
 - Added option to retain `authorization` header when a redirect happens to a different hostname
 - Reinitialize FormData stream on 307 or 308 redirects
+- Respect form-data fields ordering
 
 ## Super simple to use
 

--- a/lib/redirect.js
+++ b/lib/redirect.js
@@ -172,48 +172,25 @@ Redirect.prototype.onResponse = function (response) {
     // remove content-length header since FormValue may be dropped if its not a file stream
     request.removeHeader('content-length')
 
-    var formData = {}
-    var resetFormData = function (key, value) {
-      var newValue
-      var formValue = value && value.hasOwnProperty('value') ? value.value : value
-
-      // if `formValue` is of type stream
-      if (typeof formValue === 'object' && typeof formValue.pipe === 'function') {
+    var formData = []
+    var resetFormData = function (key, value, options) {
+      // if `value` is of type stream
+      if (typeof value === 'object' && typeof value.pipe === 'function') {
         // bail out if not a file stream
-        if (!(formValue.hasOwnProperty('fd') && formValue.path)) return
+        if (!(value.hasOwnProperty('fd') && value.path)) return
         // create new file stream
-        formValue = fs.createReadStream(formValue.path)
+        value = fs.createReadStream(value.path)
       }
 
-      if (value && value.hasOwnProperty('value') && value.hasOwnProperty('options')) {
-        newValue = { value: formValue, options: value.options }
+      if (options) {
+        formData.push({key: key, value: value, options: options})
       } else {
-        newValue = formValue
+        formData.push({key: key, value: value})
       }
-
-      if (!formData.hasOwnProperty(key)) {
-        formData[key] = newValue
-        return
-      }
-
-      // at this point, we know that form has duplicate
-      if (!Array.isArray(formData[key])) {
-        formData[key] = [formData[key]]
-      }
-
-      formData[key].push(newValue)
     }
-    for (var formKey in request.formData) {
-      if (request.formData.hasOwnProperty(formKey)) {
-        var formValue = request.formData[formKey]
-        if (Array.isArray(formValue)) {
-          for (var j = 0; j < formValue.length; j++) {
-            resetFormData(formKey, formValue[j])
-          }
-        } else {
-          resetFormData(formKey, formValue)
-        }
-      }
+    for (var i = 0, ii = request.formData.length; i < ii; i++) {
+      var formParam = request.formData[i]
+      resetFormData(formParam.key, formParam.value, formParam.options)
     }
 
     // setting `options.formData` will reinitialize FormData in `request.init`

--- a/lib/redirect.js
+++ b/lib/redirect.js
@@ -175,7 +175,7 @@ Redirect.prototype.onResponse = function (response) {
     var formData = []
     var resetFormData = function (key, value, paramOptions) {
       // if `value` is of type stream
-      if (typeof value === 'object' && typeof value.pipe === 'function') {
+      if (typeof (value && value.pipe) === 'function') {
         // bail out if not a file stream
         if (!(value.hasOwnProperty('fd') && value.path)) return
         // create new file stream

--- a/lib/redirect.js
+++ b/lib/redirect.js
@@ -186,6 +186,7 @@ Redirect.prototype.onResponse = function (response) {
     }
     for (var i = 0, ii = request.formData.length; i < ii; i++) {
       var formParam = request.formData[i]
+      if (!formParam) { continue }
       resetFormData(formParam.key, formParam.value, formParam.options)
     }
 

--- a/lib/redirect.js
+++ b/lib/redirect.js
@@ -173,7 +173,7 @@ Redirect.prototype.onResponse = function (response) {
     request.removeHeader('content-length')
 
     var formData = []
-    var resetFormData = function (key, value, options) {
+    var resetFormData = function (key, value, paramOptions) {
       // if `value` is of type stream
       if (typeof value === 'object' && typeof value.pipe === 'function') {
         // bail out if not a file stream
@@ -182,11 +182,7 @@ Redirect.prototype.onResponse = function (response) {
         value = fs.createReadStream(value.path)
       }
 
-      if (options) {
-        formData.push({key: key, value: value, options: options})
-      } else {
-        formData.push({key: key, value: value})
-      }
+      formData.push({key: key, value: value, options: paramOptions})
     }
     for (var i = 0, ii = request.formData.length; i < ii; i++) {
       var formParam = request.formData[i]

--- a/request.js
+++ b/request.js
@@ -81,11 +81,11 @@ function transformFormData (formData) {
   // https://tools.ietf.org/html/rfc7578#section-5.2
 
   var transformedFormData = []
-  var appendFormParam = function (key, value) {
+  var appendFormParam = function (key, param) {
     transformedFormData.push({
       key: key,
-      value: value && value.hasOwnProperty('value') ? value.value : value,
-      options: value && value.hasOwnProperty('options') ? value.options : undefined
+      value: param && param.hasOwnProperty('value') ? param.value : param,
+      options: param && param.hasOwnProperty('options') ? param.options : undefined
     })
   }
   for (var formKey in formData) {

--- a/request.js
+++ b/request.js
@@ -89,7 +89,7 @@ function transformFormData (formData) {
     transformedFormData.push({
       key: key,
       value: value && value.hasOwnProperty('value') ? value.value : value,
-      options: value && value.hasOwnProperty('options') ? value.options : {}
+      options: value && value.hasOwnProperty('options') ? value.options : undefined
     })
   }
   for (var formKey in formData) {
@@ -386,7 +386,11 @@ Request.prototype.init = function (options) {
     var requestForm = self.form()
     for (var i = 0, ii = formData.length; i < ii; i++) {
       var formParam = formData[i]
-      requestForm.append(formParam.key, formParam.value, formParam.options)
+      if (formParam.options) {
+        requestForm.append(formParam.key, formParam.value, formParam.options)
+      } else {
+        requestForm.append(formParam.key, formParam.value)
+      }
     }
   }
 

--- a/request.js
+++ b/request.js
@@ -71,6 +71,42 @@ function filterOutReservedFunctions (reserved, options) {
   return object
 }
 
+function transformFormData (formData) {
+  // Transform the object representation of form-data fields to array representation.
+  // This might not preserve the order of form fields defined in object representation.
+  // But, this transformation is required to support backward compatibility.
+  //
+  // Form-Data should be stored as an array to respect the fields order.
+  // RFC 7578#section-5.2  Ordered Fields and Duplicated Field Names
+  // https://tools.ietf.org/html/rfc7578#section-5.2
+
+  // bail out if `formData` is not defined or already in array form
+  // don't check for explicit object type to support legacy shenanigans
+  if (!formData || Array.isArray(formData)) return formData
+
+  var transformedFormData = []
+  var appendFormParam = function (key, value) {
+    transformedFormData.push({
+      key: key,
+      value: value && value.hasOwnProperty('value') ? value.value : value,
+      options: value && value.hasOwnProperty('options') ? value.options : {}
+    })
+  }
+  for (var formKey in formData) {
+    if (formData.hasOwnProperty(formKey)) {
+      var formValue = formData[formKey]
+      if (Array.isArray(formValue)) {
+        for (var j = 0; j < formValue.length; j++) {
+          appendFormParam(formKey, formValue[j])
+        }
+      } else {
+        appendFormParam(formKey, formValue)
+      }
+    }
+  }
+  return transformedFormData
+}
+
 // Return a simpler request object to allow serialization
 function requestToJSON () {
   var self = this
@@ -106,6 +142,11 @@ function Request (options) {
   if (options.har) {
     self._har = new Har(self)
     options = self._har.options(options)
+  }
+
+  // transform `formData` for backward compatibility
+  if (options.formData) {
+    options.formData = transformFormData(options.formData)
   }
 
   stream.Stream.call(self)
@@ -343,24 +384,9 @@ Request.prototype.init = function (options) {
   if (options.formData) {
     var formData = options.formData
     var requestForm = self.form()
-    var appendFormValue = function (key, value) {
-      if (value && value.hasOwnProperty('value') && value.hasOwnProperty('options')) {
-        requestForm.append(key, value.value, value.options)
-      } else {
-        requestForm.append(key, value)
-      }
-    }
-    for (var formKey in formData) {
-      if (formData.hasOwnProperty(formKey)) {
-        var formValue = formData[formKey]
-        if (formValue instanceof Array) {
-          for (var j = 0; j < formValue.length; j++) {
-            appendFormValue(formKey, formValue[j])
-          }
-        } else {
-          appendFormValue(formKey, formValue)
-        }
-      }
+    for (var i = 0, ii = formData.length; i < ii; i++) {
+      var formParam = formData[i]
+      requestForm.append(formParam.key, formParam.value, formParam.options)
     }
   }
 

--- a/request.js
+++ b/request.js
@@ -80,10 +80,6 @@ function transformFormData (formData) {
   // RFC 7578#section-5.2  Ordered Fields and Duplicated Field Names
   // https://tools.ietf.org/html/rfc7578#section-5.2
 
-  // bail out if `formData` is not defined or already in array form
-  // don't check for explicit object type to support legacy shenanigans
-  if (!formData || Array.isArray(formData)) return formData
-
   var transformedFormData = []
   var appendFormParam = function (key, value) {
     transformedFormData.push({
@@ -145,7 +141,8 @@ function Request (options) {
   }
 
   // transform `formData` for backward compatibility
-  if (options.formData) {
+  // don't check for explicit object type to support legacy shenanigans
+  if (options.formData && !Array.isArray(formData)) {
     options.formData = transformFormData(options.formData)
   }
 
@@ -386,6 +383,7 @@ Request.prototype.init = function (options) {
     var requestForm = self.form()
     for (var i = 0, ii = formData.length; i < ii; i++) {
       var formParam = formData[i]
+      if (!formParam) { continue }
       if (formParam.options) {
         requestForm.append(formParam.key, formParam.value, formParam.options)
       } else {

--- a/request.js
+++ b/request.js
@@ -142,7 +142,7 @@ function Request (options) {
 
   // transform `formData` for backward compatibility
   // don't check for explicit object type to support legacy shenanigans
-  if (options.formData && !Array.isArray(formData)) {
+  if (options.formData && !Array.isArray(options.formData)) {
     options.formData = transformFormData(options.formData)
   }
 

--- a/tests/test-form-data-array.js
+++ b/tests/test-form-data-array.js
@@ -96,7 +96,7 @@ function runTest (t, options) {
 
   server.listen(0, function () {
     var url = 'http://localhost:' + this.address().port
-    // @NOTE: multipartFormData properties must be set here so that my_file read stream does not leak in node v0.8
+
     multipartFormData.push({key: 'my_field', value: 'my_value'})
     multipartFormData.push({key: 'my_buffer', value: Buffer.from([1, 2, 3])})
     multipartFormData.push({key: 'my_file', value: fs.createReadStream(localFile)})

--- a/tests/test-form-data-array.js
+++ b/tests/test-form-data-array.js
@@ -6,6 +6,7 @@ var mime = require('mime-types')
 var request = require('../index')
 var fs = require('fs')
 var tape = require('tape')
+var destroyable = require('server-destroy')
 
 function runTest (t, options) {
   var remoteFile = path.join(__dirname, 'googledoodle.jpg')
@@ -91,6 +92,8 @@ function runTest (t, options) {
     })
   })
 
+  destroyable(server)
+
   server.listen(0, function () {
     var url = 'http://localhost:' + this.address().port
     // @NOTE: multipartFormData properties must be set here so that my_file read stream does not leak in node v0.8
@@ -124,7 +127,7 @@ function runTest (t, options) {
       t.equal(err, null)
       t.equal(res.statusCode, 200)
       t.deepEqual(body, options.json ? {status: 'done'} : 'done')
-      server.close(function () {
+      server.destroy(function () {
         t.end()
       })
     })

--- a/tests/test-form-data-array.js
+++ b/tests/test-form-data-array.js
@@ -1,0 +1,144 @@
+'use strict'
+
+var http = require('http')
+var path = require('path')
+var mime = require('mime-types')
+var request = require('../index')
+var fs = require('fs')
+var tape = require('tape')
+
+function runTest (t, options) {
+  var remoteFile = path.join(__dirname, 'googledoodle.jpg')
+  var localFile = path.join(__dirname, 'unicycle.jpg')
+  var multipartFormData = []
+
+  var server = http.createServer(function (req, res) {
+    if (req.url === '/file') {
+      res.writeHead(200, {'content-type': 'image/jpg', 'content-length': 7187})
+      res.end(fs.readFileSync(remoteFile), 'binary')
+      return
+    }
+
+    if (options.auth) {
+      if (!req.headers.authorization) {
+        res.writeHead(401, {'www-authenticate': 'Basic realm="Private"'})
+        res.end()
+        return
+      } else {
+        t.ok(req.headers.authorization === 'Basic ' + Buffer.from('user:pass').toString('base64'))
+      }
+    }
+
+    t.ok(/multipart\/form-data; boundary=--------------------------\d+/
+      .test(req.headers['content-type']))
+
+    // temp workaround
+    var data = ''
+    req.setEncoding('utf8')
+
+    req.on('data', function (d) {
+      data += d
+    })
+
+    req.on('end', function () {
+      // check for the fields' traces
+
+      // 1st field : my_field
+      t.ok(data.indexOf('form-data; name="my_field"') !== -1)
+      t.ok(data.indexOf(multipartFormData[0].value) !== -1)
+
+      // 2nd field : my_buffer
+      t.ok(data.indexOf('form-data; name="my_buffer"') !== -1)
+      t.ok(data.indexOf(multipartFormData[1].value) !== -1)
+
+      // 3rd field : my_file
+      t.ok(data.indexOf('form-data; name="my_file"') !== -1)
+      t.ok(data.indexOf('; filename="' + path.basename(multipartFormData[2].value.path) + '"') !== -1)
+      // check for unicycle.jpg traces
+      t.ok(data.indexOf('2005:06:21 01:44:12') !== -1)
+      t.ok(data.indexOf('Content-Type: ' + mime.lookup(multipartFormData[2].value.path)) !== -1)
+
+      // 4th field : remote_file
+      t.ok(data.indexOf('form-data; name="remote_file"') !== -1)
+      t.ok(data.indexOf('; filename="' + path.basename(multipartFormData[3].value.path) + '"') !== -1)
+
+      // 5th field : file with metadata
+      t.ok(data.indexOf('form-data; name="secret_file"') !== -1)
+      t.ok(data.indexOf('Content-Disposition: form-data; name="secret_file"; filename="topsecret.jpg"') !== -1)
+      t.ok(data.indexOf('Content-Type: image/custom') !== -1)
+
+      // 6th field : batch of files
+      t.ok(data.indexOf('form-data; name="batch"') !== -1)
+      t.ok(data.match(/form-data; name="batch"/g).length === 2)
+
+      // 7th field : 0
+      t.ok(data.indexOf('form-data; name="0"') !== -1)
+      t.ok(data.indexOf(multipartFormData[7].value) !== -1)
+
+      // check for http://localhost:nnnn/file traces
+      t.ok(data.indexOf('Photoshop ICC') !== -1)
+      t.ok(data.indexOf('Content-Type: ' + mime.lookup(remoteFile)) !== -1)
+
+      // check for form-data fields order
+      var prevFieldIndex = data.indexOf(`form-data; name="${multipartFormData[0].key}"`)
+      for (var i = 1, ii = multipartFormData.length; i < ii; i++) {
+        var fieldIndex = data.indexOf(`form-data; name="${multipartFormData[i].key}"`, prevFieldIndex + 1)
+        t.ok(fieldIndex > prevFieldIndex)
+      }
+
+      res.writeHead(200)
+      res.end(options.json ? JSON.stringify({status: 'done'}) : 'done')
+    })
+  })
+
+  server.listen(0, function () {
+    var url = 'http://localhost:' + this.address().port
+    // @NOTE: multipartFormData properties must be set here so that my_file read stream does not leak in node v0.8
+    multipartFormData.push({key: 'my_field', value: 'my_value'})
+    multipartFormData.push({key: 'my_buffer', value: Buffer.from([1, 2, 3])})
+    multipartFormData.push({key: 'my_file', value: fs.createReadStream(localFile)})
+    multipartFormData.push({key: 'remote_file', value: request(url + '/file')})
+    multipartFormData.push({
+      key: 'secret_file',
+      value: fs.createReadStream(localFile),
+      options: {
+        filename: 'topsecret.jpg',
+        contentType: 'image/custom'
+      }
+    })
+    multipartFormData.push({key: 'batch', value: fs.createReadStream(localFile)})
+    multipartFormData.push({key: 'batch', value: fs.createReadStream(localFile)})
+    multipartFormData.push({key: '0', value: 'numeric_field_value'})
+
+    var reqOptions = {
+      url: url + '/upload',
+      formData: multipartFormData
+    }
+    if (options.json) {
+      reqOptions.json = true
+    }
+    if (options.auth) {
+      reqOptions.auth = {user: 'user', pass: 'pass', sendImmediately: false}
+    }
+    request.post(reqOptions, function (err, res, body) {
+      t.equal(err, null)
+      t.equal(res.statusCode, 200)
+      t.deepEqual(body, options.json ? {status: 'done'} : 'done')
+      server.close(function () {
+        t.end()
+      })
+    })
+  })
+}
+
+tape('multipart formData', function (t) {
+  runTest(t, {json: false})
+})
+
+tape('multipart formData + JSON', function (t) {
+  runTest(t, {json: true})
+})
+
+tape('multipart formData + basic auth', function (t) {
+  runTest(t, {json: false, auth: true})
+})

--- a/tests/test-form-data-redirect.js
+++ b/tests/test-form-data-redirect.js
@@ -36,6 +36,18 @@ function runTest (t, options) {
         t.ok(data.indexOf('form-data; name="my_field_batch"') !== -1)
         t.ok(data.indexOf(multipartFormData.my_field_batch[0]) !== -1)
         t.ok(data.indexOf(multipartFormData.my_field_batch[1]) !== -1)
+      } else if (options.preserveOrder) {
+        // 1st field : my_field
+        t.ok(data.indexOf('form-data; name="my_field"') !== -1)
+        t.ok(data.indexOf(multipartFormData[0].value) !== -1)
+
+        // 2nd field : file with metadata
+        t.ok(data.indexOf('Content-Disposition: form-data; name="0"; filename="topsecret.jpg"') !== -1)
+        t.ok(data.indexOf('Content-Type: image/custom') !== -1)
+
+        // check for form-data fields order
+        t.ok(data.indexOf(`form-data; name="${multipartFormData[0].key}"`) <
+          data.indexOf(`form-data; name="${multipartFormData[1].key}"`))
       } else {
         // 1st field : my_field
         t.ok(data.indexOf('form-data; name="my_field"') !== -1)
@@ -44,11 +56,6 @@ function runTest (t, options) {
         // 2nd field : my_buffer
         t.ok(data.indexOf('form-data; name="my_buffer"') !== -1)
         t.ok(data.indexOf(multipartFormData.my_buffer) !== -1)
-
-        // 3rd field : file with metadata
-        t.ok(data.indexOf('form-data; name="secret_file"') !== -1)
-        t.ok(data.indexOf('Content-Disposition: form-data; name="secret_file"; filename="topsecret.jpg"') !== -1)
-        t.ok(data.indexOf('Content-Type: image/custom') !== -1)
       }
 
       // formdata boundary
@@ -68,16 +75,20 @@ function runTest (t, options) {
     // https://github.com/request/request/issues/887#issuecomment-347050137
     if (options.batch) {
       multipartFormData.my_field_batch = ['my_value_1', 'my_value_2']
-    } else {
-      multipartFormData.my_field = 'my_value'
-      multipartFormData.my_buffer = Buffer.from([1, 2, 3])
-      multipartFormData.secret_file = {
+    } else if (options.preserveOrder) {
+      multipartFormData = [{
+        key: 'my_field', value: 'my_value'
+      }, {
+        key: '0',
         value: fs.createReadStream(localFile),
         options: {
           filename: 'topsecret.jpg',
           contentType: 'image/custom'
         }
-      }
+      }]
+    } else {
+      multipartFormData.my_field = 'my_value'
+      multipartFormData.my_buffer = Buffer.from([1, 2, 3])
     }
 
     request.post({
@@ -108,4 +119,8 @@ tape('multipart formData + 307 redirect + batch', function (t) {
 
 tape('multipart formData + 308 redirect', function (t) {
   runTest(t, {url: '/redirect', responseCode: 308, location: '/upload'})
+})
+
+tape('multipart formData + 308 redirect + preserveOrder', function (t) {
+  runTest(t, {url: '/redirect', responseCode: 308, location: '/upload', preserveOrder: true})
 })

--- a/tests/test-form-data-redirect.js
+++ b/tests/test-form-data-redirect.js
@@ -5,6 +5,7 @@ var path = require('path')
 var request = require('../')
 var fs = require('fs')
 var tape = require('tape')
+var destroyable = require('server-destroy')
 
 function runTest (t, options) {
   var localFile = path.join(__dirname, 'unicycle.jpg')
@@ -58,6 +59,8 @@ function runTest (t, options) {
     })
   })
 
+  destroyable(server)
+
   // this will cause servers to listen on a random port
   server.listen(0, function () {
     var url = 'http://localhost:' + this.address().port
@@ -86,7 +89,7 @@ function runTest (t, options) {
       t.equal(redirects, 1)
       t.equal(res.statusCode, 200)
       t.deepEqual(body, options.json ? {status: 'done'} : 'done')
-      server.close(function () {
+      server.destroy(function () {
         t.end()
       })
     }).on('redirect', function () {

--- a/tests/test-form-data-redirect.js
+++ b/tests/test-form-data-redirect.js
@@ -8,7 +8,7 @@ var tape = require('tape')
 var destroyable = require('server-destroy')
 
 function runTest (t, options) {
-  var localFile = path.join(__dirname, 'unicycle.jpg')
+  var localFile = path.join(__dirname, 'googledoodle.jpg')
   var multipartFormData = {}
   var redirects = 0
 

--- a/tests/test-form-data-redirect.js
+++ b/tests/test-form-data-redirect.js
@@ -77,7 +77,8 @@ function runTest (t, options) {
       multipartFormData.my_field_batch = ['my_value_1', 'my_value_2']
     } else if (options.preserveOrder) {
       multipartFormData = [{
-        key: 'my_field', value: 'my_value'
+        key: 'my_field',
+        value: 'my_value'
       }, {
         key: '0',
         value: fs.createReadStream(localFile),

--- a/tests/test-form-data.js
+++ b/tests/test-form-data.js
@@ -6,6 +6,7 @@ var mime = require('mime-types')
 var request = require('../index')
 var fs = require('fs')
 var tape = require('tape')
+var destroyable = require('server-destroy')
 
 function runTest (t, options) {
   var remoteFile = path.join(__dirname, 'googledoodle.jpg')
@@ -80,6 +81,8 @@ function runTest (t, options) {
     })
   })
 
+  destroyable(server)
+
   server.listen(0, function () {
     var url = 'http://localhost:' + this.address().port
     // @NOTE: multipartFormData properties must be set here so that my_file read stream does not leak in node v0.8
@@ -113,7 +116,7 @@ function runTest (t, options) {
       t.equal(err, null)
       t.equal(res.statusCode, 200)
       t.deepEqual(body, options.json ? {status: 'done'} : 'done')
-      server.close(function () {
+      server.destroy(function () {
         t.end()
       })
     })


### PR DESCRIPTION
## PR Checklist:
- [x] I have run `npm test` locally and all tests are passing.
- [x] I have added/updated tests for any new behavior.
       <!-- Request is a complex project, there are VERY FEW exceptions
               where a new test is not required for new behavior. -->
- [x] If this is a significant change, an issue has already been created where the problem / solution was discussed: https://github.com/postmanlabs/postman-app-support/issues/4461
       <!-- If you'd like to suggest a significant change to request,
               please create an issue to discuss those changes and gather
               feedback BEFORE submitting your PR. -->


## PR Description
- Define formData in array representation to preserve the order.
- Supports backward compatibility.
```javascript
formData: [{
  key: 'field_name',
  value: 'field_value',
  options: {...}
}]
```