### PR TITLE
Remove authorization header while redirecting to different host

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This is a fork of the excellent `request` module, which is used inside Postman R
 - Added option to retain `authorization` header when a redirect happens to a different hostname
 - Reinitialize FormData stream on 307 or 308 redirects
 - Respect form-data fields ordering
+- Fixed authentication leak in 307 and 308 redirects
 
 ## Super simple to use
 

--- a/lib/redirect.js
+++ b/lib/redirect.js
@@ -124,8 +124,10 @@ Redirect.prototype.onResponse = function (response) {
   self.redirects.push({ statusCode: response.statusCode, redirectUri: redirectTo })
 
   // if the redirect hostname (not just port or protocol) is changed:
-  //  1. remove host header
-  //  2. remove authorization header
+  //  1. remove host header, the new host will be populated on request.init
+  //  2. remove authorization header, avoid authentication leak
+  // @note: This is done because of security reasons, irrespective of the
+  // status code or request method used.
   if (request.headers && uriPrev.hostname !== request.uri.hostname) {
     request.removeHeader('host')
 
@@ -139,9 +141,14 @@ Redirect.prototype.onResponse = function (response) {
   delete request.req
   delete request._started
 
+  // if statusCode code is 401, 307 or 308:
+  //  1. Switch request method to GET if followOriginalHttpMethod is not set
+  //  2. Remove request body on redirect
   if (response.statusCode !== 401 && response.statusCode !== 307 && response.statusCode !== 308) {
     // force all redirects to use GET (due to legacy shenanigans)
     // use followOriginalHttpMethod option to avoid this
+    // @todo: figure out why its only done for HEAD method and not for similar
+    // request methods like OPTIONS or CONNECT.
     if (!self.followOriginalHttpMethod && request.method !== 'HEAD') {
       request.method = 'GET'
     }

--- a/lib/redirect.js
+++ b/lib/redirect.js
@@ -121,26 +121,31 @@ Redirect.prototype.onResponse = function (response) {
     delete request.agent
   }
 
-  // remove the host header if the response is a 307 or 308, & the host has changed.
-  // (the new host will be populated auto-magically).
-  // For other types of redirects, it's removed automatically (see code below)
-  if (self.followAllRedirects &&
-    (response.statusCode === 307 || response.statusCode === 308) &&
-    request.headers && uriPrev.host !== request.uri.host) {
-    request.removeHeader('host')
-  }
-
   self.redirects.push({ statusCode: response.statusCode, redirectUri: redirectTo })
 
-  if (self.followAllRedirects && request.method !== 'HEAD' &&
-    response.statusCode !== 401 && response.statusCode !== 307 && response.statusCode !== 308) {
-    request.method = self.followOriginalHttpMethod ? request.method : 'GET'
+  // if the redirect hostname (not just port or protocol) is changed:
+  //  1. remove host header
+  //  2. remove authorization header
+  if (request.headers && uriPrev.hostname !== request.uri.hostname) {
+    request.removeHeader('host')
+
+    // use followAuthorizationHeader option to retain authorization header
+    if (!self.followAuthorizationHeader) {
+      request.removeHeader('authorization')
+    }
   }
-  // request.method = 'GET' // Force all redirects to use GET || commented out fixes #215
+
   delete request.src
   delete request.req
   delete request._started
+
   if (response.statusCode !== 401 && response.statusCode !== 307 && response.statusCode !== 308) {
+    // force all redirects to use GET (due to legacy shenanigans)
+    // use followOriginalHttpMethod option to avoid this
+    if (!self.followOriginalHttpMethod && request.method !== 'HEAD') {
+      request.method = 'GET'
+    }
+
     // Remove parameters from the previous response, unless this is the second request
     // for a server that requires digest authentication.
     delete request.body
@@ -149,13 +154,6 @@ Redirect.prototype.onResponse = function (response) {
       request.removeHeader('host')
       request.removeHeader('content-type')
       request.removeHeader('content-length')
-      if (!self.followAuthorizationHeader && request.uri.hostname !== request.originalHost.split(':')[0]) {
-        // Remove authorization if changing hostnames (but not if just
-        // changing ports or protocols).  This matches the behavior of curl:
-        // https://github.com/bagder/curl/blob/6beb0eee/lib/http.c#L710
-        // Change this behavior using the followAuthorizationHeader option
-        request.removeHeader('authorization')
-      }
     }
   } else if (request.formData &&
       // make sure _form is released and there's no pending _streams left

--- a/tests/test-follow-auth-header.js
+++ b/tests/test-follow-auth-header.js
@@ -6,86 +6,95 @@ var destroyable = require('server-destroy')
 var server = require('./server')
 var request = require('../index')
 
-var s = server.createServer()
+function runTest (t, statusCode, followAuthorizationHeader) {
+  var s = server.createServer()
+  var redirects = 0
+  var authHeader = 'Basic aGVsbG86d29ybGQ='
 
-destroyable(s)
+  destroyable(s)
 
-s.on('/', function (req, res) {
-  if (req.headers.host === `${s.redirectHost}:${s.port}`) {
-    res.writeHead(302, { location: `http://${s.respondHost}:${s.port}/` })
-    res.end()
-  } else if (req.headers.host === `${s.respondHost}:${s.port}`) {
-    res.writeHead(200)
-    res.end('ok')
-  } else {
-    res.writeHead(400)
-    res.end('unknown host')
-  }
-})
+  s.on('/', function (req, res) {
+    if (req.headers.host === `${s.redirectHost}:${s.port}`) {
+      res.writeHead(statusCode || 302, {
+        location: `http://${s.respondHost}:${s.port}/`
+      })
+      res.end()
+    } else if (req.headers.host === `${s.respondHost}:${s.port}`) {
+      res.writeHead(200)
+      res.end('ok')
+    } else {
+      res.writeHead(400)
+      res.end('unknown host')
+    }
+  })
 
-tape('setup', function (t) {
   s.listen(0, function () {
     s.redirectHost = 'test1.local.omg' // resolves to 127.0.0.1
     s.respondHost = 'test2.local.omg' // resolves to 127.0.0.1
-    t.end()
+
+    request({
+      url: `http://${s.redirectHost}:${s.port}`,
+      headers: {
+        authorization: authHeader
+      },
+      followAllRedirects: true,
+      followRedirect: true,
+      followAuthorizationHeader: followAuthorizationHeader,
+      lookup: function (hostname, options, callback) {
+        callback(null, '127.0.0.1', 4) // All hosts will resolve to 127.0.0.1
+      }
+    }, function (err, res, body) {
+      t.equal(err, null)
+      t.equal(redirects, 1)
+      t.equal(body.toString(), 'ok')
+      t.equal(res.request.headers.authorization, followAuthorizationHeader ? authHeader : undefined)
+      s.destroy(function () {
+        t.end()
+      })
+    }).on('redirect', function () {
+      redirects++
+      t.equal(this.response.statusCode, statusCode)
+      t.equal(this.uri.href, `http://${s.respondHost}:${s.port}/`)
+    })
   })
+}
+
+tape('301 redirect', function (t) {
+  runTest(t, 301)
 })
 
-tape('drop authorization header when redirects to different host', function (t) {
-  var redirects = 0
-  var authHeader = 'Basic aGVsbG86d29ybGQ='
-
-  request({
-    url: `http://${s.redirectHost}:${s.port}/`,
-    headers: {
-      authorization: authHeader
-    },
-    followAllRedirects: true,
-    followRedirect: true,
-    lookup: function (hostname, options, callback) {
-      callback(null, '127.0.0.1', 4) // All hosts will resolve to 127.0.0.1
-    }
-  }, function (err, res, body) {
-    t.equal(err, null)
-    t.equal(redirects, 1)
-    t.equal(body.toString(), 'ok')
-    t.equal(res.request.headers.authorization, undefined)
-    t.end()
-  }).on('redirect', function () {
-    redirects++
-    t.equal(this.uri.href, `http://${s.respondHost}:${s.port}/`)
-  })
+tape('301 redirect + followAuthorizationHeader', function (t) {
+  runTest(t, 301, true)
 })
 
-tape('retain authorization header on redirects when using followAuthorizationHeader', function (t) {
-  var redirects = 0
-  var authHeader = 'Basic aGVsbG86d29ybGQ='
-
-  request({
-    url: `http://${s.redirectHost}:${s.port}/`,
-    headers: {
-      authorization: authHeader
-    },
-    followAllRedirects: true,
-    followRedirect: true,
-    followAuthorizationHeader: true,
-    lookup: function (hostname, options, callback) {
-      callback(null, '127.0.0.1', 4) // All hosts will resolve to 127.0.0.1
-    }
-  }, function (err, res, body) {
-    t.equal(err, null)
-    t.equal(redirects, 1)
-    t.equal(body.toString(), 'ok')
-    t.equal(res.request.headers.authorization, authHeader)
-    t.end()
-  }).on('redirect', function () {
-    redirects++
-    t.equal(this.uri.href, `http://${s.respondHost}:${s.port}/`)
-  })
+tape('302 redirect', function (t) {
+  runTest(t, 302)
 })
 
-tape('cleanup', function (t) {
-  s.destroy(function () {
-    t.end()
-  })
+tape('302 redirect + followAuthorizationHeader', function (t) {
+  runTest(t, 302, true)
+})
+
+tape('303 redirect', function (t) {
+  runTest(t, 303)
+})
+
+tape('303 redirect + followAuthorizationHeader', function (t) {
+  runTest(t, 303, true)
+})
+
+tape('307 redirect', function (t) {
+  runTest(t, 307)
+})
+
+tape('307 redirect + followAuthorizationHeader', function (t) {
+  runTest(t, 307, true)
+})
+
+tape('308 redirect', function (t) {
+  runTest(t, 308)
+})
+
+tape('308 redirect + followAuthorizationHeader', function (t) {
+  runTest(t, 308, true)
 })

--- a/tests/test-redirect.js
+++ b/tests/test-redirect.js
@@ -268,7 +268,7 @@ tape('should follow delete redirects when followallredirects true', function (t)
   })
 })
 
-// @note Previously all the methods get redirected with there request method
+// @note Previously all the methods get redirected with their request method
 // preserved(not changed to GET) other than the following 4:
 // PATCH, PUT, POST, DELETE (Probably accounted for only GET & HEAD).
 // BUT, with followAllRedirects set, the request method is changed to GET for


### PR DESCRIPTION
## PR Checklist:
- [x] I have run `npm test` locally and all tests are passing.
- [x] I have added/updated tests for any new behavior.
       <!-- Request is a complex project, there are VERY FEW exceptions
               where a new test is not required for new behavior. -->
- [x] If this is a significant change, an issue has already been created where the problem / solution was discussed: https://curl.haxx.se/docs/CVE-2018-1000007.html
       <!-- If you'd like to suggest a significant change to request,
               please create an issue to discuss those changes and gather
               feedback BEFORE submitting your PR. -->


## PR Description
- Handle `Authorization` header on redirects correctly
- Cleanup repetitive logic in `redirect.js`