### PR TITLE
Support for '#' in query parameters, Fixes Runtime-5779 

### DIFF
--- a/lib/url-parse.js
+++ b/lib/url-parse.js
@@ -5,6 +5,7 @@ var STRING = 'string'
 var AMPERSAND = '&'
 var EQUALS = '='
 var QUESTION_MARK = '?'
+var FORWARD_SLASHES = '//'
 var stringify
 var parse
 
@@ -84,19 +85,21 @@ module.exports = function (str) {
   rawQs = parsed.query
 
   if (rawQs && rawQs.length) {
-    qs = stringify(parse(parsed.query))
+    qs = parsed.hash ? stringify(parse(parsed.query + parsed.hash))
+      : stringify(parse(parsed.query))
     search = QUESTION_MARK + qs
     path = parsed.pathname + search
 
     parsed.query = qs
     parsed.search = search
     parsed.path = path
-
     str = url.format(parsed)
   }
 
   // Parse again, because Node does not guarantee consistency of properties
-  return url.parse(str)
+  parsed = url.parse(str)
+  parsed.href = parsed.protocol + FORWARD_SLASHES + parsed.hostname + parsed.pathname + parsed.search
+  return parsed
 }
 
 module.exports.parse = parse

--- a/tests/test-qs.js
+++ b/tests/test-qs.js
@@ -53,6 +53,7 @@ function esc (str) {
   return str
     .replace(/\[/g, '%5B')
     .replace(/\]/g, '%5D')
+    .replace(/#/g, '%23')
 }
 
 runTest('adding a querystring', {
@@ -100,6 +101,21 @@ runTest('a query with an array for a value', {
   qs: { order: ['bar', 'desc'] },
   expected: esc('/?order[0]=bar&order[1]=desc'),
   expectedQuerystring: '/?order=bar&order=desc'
+})
+
+runTest('a query with # in key', {
+  qs: { 'user#1': 'someUser' },
+  expected: esc('/?user#1=someUser')
+})
+
+runTest('a query with # in value', {
+  qs: { 'user1': 'someUser#1' },
+  expected: esc('/?user1=someUser#1')
+})
+
+runTest('a query with # in key and value', {
+  qs: { 'user#1': 'someUser#1' },
+  expected: esc('/?user#1=someUser#1')
 })
 
 runTest('pass options to the qs module via the qsParseOptions key', {

--- a/tests/test-url-parse.js
+++ b/tests/test-url-parse.js
@@ -3,6 +3,11 @@
 var url = require('../lib/url-parse')
 var tape = require('tape')
 
+function esc (str) {
+  return str
+    .replace(/#/g, '%23')
+}
+
 tape('parse - "a=b&c=d"', function (t) {
   var str = 'a=b&c=d'
   t.deepEqual(url.parse(str), [
@@ -347,4 +352,26 @@ tape('url parse with invalid encoded parameters - ""', function (t) {
     url('http://httpbin.org/get?&c=%d')
     t.end()
   })
+})
+
+tape('url parse with # in query parameters - ""', function (t) {
+  var parsed = url('http://httpbin.org/get?user#1=someUser')
+
+  t.equal(parsed.search, esc('?user#1=someUser'))
+  t.equal(parsed.query, esc('user#1=someUser'))
+  t.equal(parsed.path, esc('/get?user#1=someUser'))
+  t.equal(parsed.href, esc('http://httpbin.org/get?user#1=someUser'))
+
+  t.end()
+})
+
+tape('url parse with multiple # in query parameters - ""', function (t) {
+  var parsed = url('http://httpbin.org/get?user#1=someUser&user#2=someUser#2')
+
+  t.equal(parsed.search, esc('?user#1=someUser&user#2=someUser#2'))
+  t.equal(parsed.query, esc('user#1=someUser&user#2=someUser#2'))
+  t.equal(parsed.path, esc('/get?user#1=someUser&user#2=someUser#2'))
+  t.equal(parsed.href, esc('http://httpbin.org/get?user#1=someUser&user#2=someUser#2'))
+
+  t.end()
 })


### PR DESCRIPTION
Currently, if # is used in query parameters they are not parsed properly, although rfc3986 declares it as one of the reserved characters it also specifies that if needed these reserved characters can be used by percent-encoding. https://github.com/postmanlabs/postman-app-support/issues/5779

