### PR TITLE
Added support for extending the root CA certificates

### DIFF
--- a/README.md
+++ b/README.md
@@ -686,7 +686,7 @@ request.get({
 
 The `ca` value can be an array of certificates, in the event you have a private or internal corporate public-key infrastructure hierarchy. For example, if you want to connect to https://api.some-server.com which presents a key chain consisting of:
 1. its own public key, which is signed by:
-2. an intermediate "Corp Issuing Server", that is in turn signed by: 
+2. an intermediate "Corp Issuing Server", that is in turn signed by:
 3. a root CA "Corp Root CA";
 
 you can configure your request as follows:
@@ -701,6 +701,27 @@ request.get({
         ]
     }
 });
+```
+
+### Extending root CAs
+
+When this feature is enabled, the root CAs can be extended using the `extraCA` option. The file should consist of one or more trusted certificates in PEM format.
+
+This is similar to [NODE_EXTRA_CA_CERTS](https://nodejs.org/api/cli.html#cli_node_extra_ca_certs_file). But, if `options.ca` is specified, those will be extended as well.
+
+```js
+// enable extending CAs
+request.enableNodeExtraCACerts();
+
+// request with extra CA certs
+request.get({
+    url: 'https://api.some-server.com/',
+    extraCA: fs.readFileSync('Extra CA Certificates .pem')
+});
+
+// disable this feature
+request.disableNodeExtraCACerts()
+
 ```
 
 [back to top](#table-of-contents)

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This is a fork of the excellent `request` module, which is used inside Postman R
 - Fixed authentication leak in 307 and 308 redirects
 - Added `secureConnect` to timings and `secureHandshake` to timingPhases
 - Fixed `Request~getNewAgent` to account for `passphrase` while generating poolKey
+- Added support for extending the root CA certificates.
 
 ## Super simple to use
 

--- a/index.js
+++ b/index.js
@@ -155,18 +155,18 @@ request.forever = function (agentOptions, optionsArg) {
 request.enableNodeExtraCACerts = function () {
   // bail out if already enabled
   if (tls.__createSecureContext) {
-    return;
+    return
   }
 
   // store the original tls.createSecureContext method.
   // used to extend existing functionality as well as restore later.
-  tls.__createSecureContext = tls.createSecureContext;
+  tls.__createSecureContext = tls.createSecureContext
 
   // override tls.createSecureContext with extraCA support
   // @note if agent is keepAlive, same context will be reused.
   tls.createSecureContext = function () {
     // call original createSecureContext and store the context
-    var secureContext = tls.__createSecureContext.apply(this, arguments);
+    var secureContext = tls.__createSecureContext.apply(this, arguments)
 
     // if `extraCA` is present in options, extend CA certs
     // @note this request option is available here because all the
@@ -177,25 +177,25 @@ request.enableNodeExtraCACerts = function () {
       // extend root CA with specified CA certificates
       // @note `addCACert` is an undocumented API and performs an expensive operations
       // Refer: https://github.com/nodejs/node/blob/v10.15.1/lib/_tls_common.js#L97
-      secureContext.context.addCACert(arguments[0].extraCA);
+      secureContext.context.addCACert(arguments[0].extraCA)
     }
 
-    return secureContext;
-  };
+    return secureContext
+  }
 }
 
 // disable the extended CA certificates feature
 request.disableNodeExtraCACerts = function () {
   // bail out if not enabled
   if (typeof tls.__createSecureContext !== 'function') {
-    return;
+    return
   }
 
   // reset `tls.createSecureContext` with the original method
-  tls.createSecureContext = tls.__createSecureContext;
+  tls.createSecureContext = tls.__createSecureContext
 
   // delete the reference of original method
-  delete tls.__createSecureContext;
+  delete tls.__createSecureContext
 }
 
 // Exports

--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@
 
 'use strict'
 
+var tls = require('tls')
 var extend = require('extend')
 var cookies = require('./lib/cookies')
 
@@ -128,6 +129,73 @@ request.forever = function (agentOptions, optionsArg) {
 
   options.forever = true
   return request.defaults(options)
+}
+
+// As of now(Node v10.x LTS), the only way to extend the well known "root" CA
+// is by using an environment variable called `NODE_EXTRA_CA_CERTS`.
+// This function enables the same functionality and provides a programmatic way
+// to extend the CA certificates.
+// Refer: https://nodejs.org/docs/latest-v10.x/api/cli.html#cli_node_extra_ca_certs_file
+//
+// @note Unlike NODE_EXTRA_CA_CERTS, this method extends the CA for every
+// request sent and since its an expensive operation its advised to use a
+// keepAlive agent(agentOptions.keepAlive: true) when this is enabled.
+//
+//   Benchmarks using a local server:
+//     NODE_EXTRA_CA_CERTS (keepAlive: false) : 422 ops/sec ±1.73% (77 runs sampled)
+//     NODE_EXTRA_CA_CERTS (keepAlive: true)  : 2,096 ops/sec ±4.23% (69 runs sampled)
+//
+//     enableNodeExtraCACerts (keepAlive: false) : 331 ops/sec ±5.64% (77 runs sampled)
+//     enableNodeExtraCACerts (keepAlive: true)  : 2,045 ops/sec ±5.20% (69 runs sampled)
+//
+// @note Enabling this will override the singleton `tls.createSecureContext` method
+// which will be affected for every request sent(using native HTTPS etc.) on the
+// same process. BUT, this will only be effective when `extraCA` option is
+// passed to `tls.createSecureContext`, which is limited to this library.
+request.enableNodeExtraCACerts = function () {
+  // bail out if already enabled
+  if (tls.__createSecureContext) {
+    return;
+  }
+
+  // store the original tls.createSecureContext method.
+  // used to extend existing functionality as well as restore later.
+  tls.__createSecureContext = tls.createSecureContext;
+
+  // override tls.createSecureContext with extraCA support
+  // @note if agent is keepAlive, same context will be reused.
+  tls.createSecureContext = function () {
+    // call original createSecureContext and store the context
+    var secureContext = tls.__createSecureContext.apply(this, arguments);
+
+    // if `extraCA` is present in options, extend CA certs
+    // @note this request option is available here because all the
+    // Request properties are passed to HTTPS Agent.
+    if (arguments[0] && arguments[0].extraCA &&
+      secureContext && secureContext.context &&
+      typeof secureContext.context.addCACert === 'function') {
+      // extend root CA with specified CA certificates
+      // @note `addCACert` is an undocumented API and performs an expensive operations
+      // Refer: https://github.com/nodejs/node/blob/v10.15.1/lib/_tls_common.js#L97
+      secureContext.context.addCACert(arguments[0].extraCA);
+    }
+
+    return secureContext;
+  };
+}
+
+// disable the extended CA certificates feature
+request.disableNodeExtraCACerts = function () {
+  // bail out if not enabled
+  if (typeof tls.__createSecureContext !== 'function') {
+    return;
+  }
+
+  // reset `tls.createSecureContext` with the original method
+  tls.createSecureContext = tls.__createSecureContext;
+
+  // delete the reference of original method
+  delete tls.__createSecureContext;
 }
 
 // Exports

--- a/index.js
+++ b/index.js
@@ -131,7 +131,7 @@ request.forever = function (agentOptions, optionsArg) {
   return request.defaults(options)
 }
 
-// As of now(Node v10.x LTS), the only way to extend the well known "root" CA
+// As of now (Node v10.x LTS), the only way to extend the well known "root" CA
 // is by using an environment variable called `NODE_EXTRA_CA_CERTS`.
 // This function enables the same functionality and provides a programmatic way
 // to extend the CA certificates.
@@ -149,13 +149,31 @@ request.forever = function (agentOptions, optionsArg) {
 //     enableNodeExtraCACerts (keepAlive: true)  : 2,045 ops/sec ±5.20% (69 runs sampled)
 //
 // @note Enabling this will override the singleton `tls.createSecureContext` method
-// which will be affected for every request sent(using native HTTPS etc.) on the
+// which will be affected for every request sent (using native HTTPS etc.) on the
 // same process. BUT, this will only be effective when `extraCA` option is
 // passed to `tls.createSecureContext`, which is limited to this library.
-request.enableNodeExtraCACerts = function () {
+request.enableNodeExtraCACerts = function (callback) {
+  // @note callback is optional to catch missing tls method
+  !callback && (callback = function () {})
+
   // bail out if already enabled
   if (tls.__createSecureContext) {
-    return
+    return callback()
+  }
+
+  // enable only if `SecureContext.addCACert` is present
+  // otherwise return callback with error.
+  // @note try-catch is used to make sure testing this will not break
+  // the main process due to OpenSSL error.
+  try {
+    var testContext = tls.createSecureContext()
+
+    if (!(testContext && testContext.context &&
+        typeof testContext.context.addCACert === 'function')) {
+      return callback(new Error('SecureContext.addCACert is not a function'))
+    }
+  } catch (err) {
+    return callback(err)
   }
 
   // store the original tls.createSecureContext method.
@@ -171,9 +189,7 @@ request.enableNodeExtraCACerts = function () {
     // if `extraCA` is present in options, extend CA certs
     // @note this request option is available here because all the
     // Request properties are passed to HTTPS Agent.
-    if (arguments[0] && arguments[0].extraCA &&
-      secureContext && secureContext.context &&
-      typeof secureContext.context.addCACert === 'function') {
+    if (arguments[0] && arguments[0].extraCA) {
       // extend root CA with specified CA certificates
       // @note `addCACert` is an undocumented API and performs an expensive operations
       // Refer: https://github.com/nodejs/node/blob/v10.15.1/lib/_tls_common.js#L97
@@ -182,6 +198,9 @@ request.enableNodeExtraCACerts = function () {
 
     return secureContext
   }
+
+  // enabled extra CA support
+  return callback()
 }
 
 // disable the extended CA certificates feature

--- a/request.js
+++ b/request.js
@@ -1,5 +1,6 @@
 'use strict'
 
+var tls = require('tls')
 var http = require('http')
 var https = require('https')
 var url = require('url')
@@ -660,6 +661,9 @@ Request.prototype.getNewAgent = function () {
   if (self.ca) {
     options.ca = self.ca
   }
+  if (self.extraCA) {
+    options.extraCA = self.extraCA
+  }
   if (self.ciphers) {
     options.ciphers = self.ciphers
   }
@@ -708,7 +712,8 @@ Request.prototype.getNewAgent = function () {
       poolKey += options.ca
     }
 
-    if (options.extraCA) {
+    // only add when NodeExtraCACerts is enabled
+    if (tls.__createSecureContext && options.extraCA) {
       if (poolKey) {
         poolKey += ':'
       }

--- a/request.js
+++ b/request.js
@@ -708,6 +708,13 @@ Request.prototype.getNewAgent = function () {
       poolKey += options.ca
     }
 
+    if (options.extraCA) {
+      if (poolKey) {
+        poolKey += ':'
+      }
+      poolKey += options.extraCA
+    }
+
     if (typeof options.rejectUnauthorized !== 'undefined') {
       if (poolKey) {
         poolKey += ':'

--- a/tests/test-api.js
+++ b/tests/test-api.js
@@ -65,7 +65,23 @@ tape('enableNodeExtraCACerts: with missing addCACert', function (t) {
   }
 
   request.enableNodeExtraCACerts(function (err) {
-    t.ok(err, 'SecureContext.addCACert is not a function')
+    t.ok(err)
+    t.equal(err.message, 'SecureContext.addCACert is not a function')
+    t.equal(typeof tls.__createSecureContext, 'undefined')
+    tls.createSecureContext = origCreateSecureContext // RESET
+    t.end()
+  })
+})
+
+tape('enableNodeExtraCACerts: on createSecureContext error', function (t) {
+  // override createSecureContext
+  tls.createSecureContext = function () {
+    throw 'something went wrong';
+  }
+
+  request.enableNodeExtraCACerts(function (err) {
+    t.ok(err)
+    t.equal(err, 'something went wrong')
     t.equal(typeof tls.__createSecureContext, 'undefined')
     tls.createSecureContext = origCreateSecureContext // RESET
     t.end()

--- a/tests/test-api.js
+++ b/tests/test-api.js
@@ -76,12 +76,12 @@ tape('enableNodeExtraCACerts: with missing addCACert', function (t) {
 tape('enableNodeExtraCACerts: on createSecureContext error', function (t) {
   // override createSecureContext
   tls.createSecureContext = function () {
-    throw 'something went wrong'
+    throw new Error('something went wrong')
   }
 
   request.enableNodeExtraCACerts(function (err) {
     t.ok(err)
-    t.equal(err, 'something went wrong')
+    t.equal(err.message, 'something went wrong')
     t.equal(typeof tls.__createSecureContext, 'undefined')
     tls.createSecureContext = origCreateSecureContext // RESET
     t.end()

--- a/tests/test-api.js
+++ b/tests/test-api.js
@@ -76,7 +76,7 @@ tape('enableNodeExtraCACerts: with missing addCACert', function (t) {
 tape('enableNodeExtraCACerts: on createSecureContext error', function (t) {
   // override createSecureContext
   tls.createSecureContext = function () {
-    throw 'something went wrong';
+    throw 'something went wrong'
   }
 
   request.enableNodeExtraCACerts(function (err) {

--- a/tests/test-ssl.js
+++ b/tests/test-ssl.js
@@ -106,6 +106,35 @@ tape('pfx + passphrase(invalid)', function (t) {
   })
 })
 
+tape('extraCA(enabled)', function (t) {
+  // enable extraCA support
+  request.enableNodeExtraCACerts();
+
+  request({
+    url: sslServer.url,
+    extraCA: ca,
+    key: clientKey,
+    cert: clientCert
+  }, function (err, res, body) {
+    t.equal(err, null)
+    t.equal(body.toString(), 'authorized')
+    request.disableNodeExtraCACerts()
+    t.end()
+  })
+})
+
+tape('extraCA(disabled)', function (t) {
+  request({
+    url: sslServer.url,
+    extraCA: ca,
+    key: clientKey,
+    cert: clientCert
+  }, function (err, res, body) {
+    t.ok(err)
+    t.end()
+  })
+})
+
 tape('cleanup', function (t) {
   sslServer.close(function () {
     t.end()

--- a/tests/test-ssl.js
+++ b/tests/test-ssl.js
@@ -106,9 +106,9 @@ tape('pfx + passphrase(invalid)', function (t) {
   })
 })
 
-tape('extraCA(enabled)', function (t) {
+tape('extraCA(NodeExtraCACerts: enabled)', function (t) {
   // enable extraCA support
-  request.enableNodeExtraCACerts();
+  request.enableNodeExtraCACerts()
 
   request({
     url: sslServer.url,
@@ -123,7 +123,7 @@ tape('extraCA(enabled)', function (t) {
   })
 })
 
-tape('extraCA(disabled)', function (t) {
+tape('extraCA(NodeExtraCACerts: disabled)', function (t) {
   request({
     url: sslServer.url,
     extraCA: ca,
@@ -131,6 +131,24 @@ tape('extraCA(disabled)', function (t) {
     cert: clientCert
   }, function (err, res, body) {
     t.ok(err)
+    t.end()
+  })
+})
+
+tape('ca + extraCA(NodeExtraCACerts: enabled)', function (t) {
+  // enable extraCA support
+  request.enableNodeExtraCACerts()
+
+  request({
+    url: sslServer.url,
+    ca: ca,
+    extraCA: '---INVALID CERT---', // make sure this won't affect options.ca
+    key: clientKey,
+    cert: clientCert
+  }, function (err, res, body) {
+    t.equal(err, null)
+    t.equal(body.toString(), 'authorized')
+    request.disableNodeExtraCACerts()
     t.end()
   })
 })

--- a/tests/test-ssl.js
+++ b/tests/test-ssl.js
@@ -118,7 +118,7 @@ tape('extraCA(NodeExtraCACerts: enabled)', function (t) {
   }, function (err, res, body) {
     t.equal(err, null)
     t.equal(body.toString(), 'authorized')
-    request.disableNodeExtraCACerts()
+    request.disableNodeExtraCACerts() // RESET
     t.end()
   })
 })
@@ -148,7 +148,7 @@ tape('ca + extraCA(NodeExtraCACerts: enabled)', function (t) {
   }, function (err, res, body) {
     t.equal(err, null)
     t.equal(body.toString(), 'authorized')
-    request.disableNodeExtraCACerts()
+    request.disableNodeExtraCACerts() // RESET
     t.end()
   })
 })


### PR DESCRIPTION
## PR Checklist:
- [x] I have run `npm test` locally and all tests are passing.
- [x] I have added/updated tests for any new behavior.
       <!-- Request is a complex project, there are VERY FEW exceptions
               where a new test is not required for new behavior. -->
- [x] If this is a significant change, an issue has already been created where the problem / solution was discussed: https://github.com/postmanlabs/postman-app-support/issues/3290
       <!-- If you'd like to suggest a significant change to request,
               please create an issue to discuss those changes and gather
               feedback BEFORE submitting your PR. -->


## PR Description
Add support for extending the root CA certificates.

```javascript
const request = require('postman-request');

// enable this feature
request.enableNodeExtraCACerts();

// request with extra CA certs
request({... extraCA: 'string/buffer'})

// disable this feature
request.disableNodeExtraCACerts()
```

Benchmarks:
```
with options.ca:
  keepAlive: true = 1,806 ops/sec ±4.98% (73 runs sampled)
  keepAlive: false = 414 ops/sec ±2.02% (75 runs sampled)

with process.env.NODE_EXTRA_CA_CERTS:
  keepAlive: true = 2,096 ops/sec ±4.23% (69 runs sampled)
  keepAlive: false = 422 ops/sec ±1.73% (77 runs sampled)

with request.enableNodeExtraCACerts():
  keepAlive: true = 2,045 ops/sec ±5.20% (69 runs sampled)
  keepAlive: false = 331 ops/sec ±5.64% (77 runs sampled)
```