### PR TITLE
Add disablePostmanUrlEncoder option

### DIFF
--- a/README.md
+++ b/README.md
@@ -969,6 +969,7 @@ The first argument can be either a `url` or an `options` object. The only requir
 
 ---
 
+- `disablePostmanUrlEncoder` - if `true`, it will not use postman-url-encoder to encode URL. It means that if URL is given as object, it will be used as it is without doing any encoding. But if URL is given as string, it will be encoded by Node while converting it to object.
 - `time` - if `true`, the request-response cycle (including all redirects) is timed at millisecond resolution. When set, the following properties are added to the response object:
   - `elapsedTime` Duration of the entire request/response in milliseconds (*deprecated*).
   - `responseStartTime` Timestamp when the response began (in Unix Epoch milliseconds) (*deprecated*).

--- a/README.md
+++ b/README.md
@@ -969,7 +969,7 @@ The first argument can be either a `url` or an `options` object. The only requir
 
 ---
 
-- `disablePostmanUrlEncoder` - if `true`, it will not use postman-url-encoder to encode URL. It means that if URL is given as object, it will be used as it is without doing any encoding. But if URL is given as string, it will be encoded by Node while converting it to object.
+- `disableUrlEncoding` - if `true`, it will not use postman-url-encoder to encode URL. It means that if URL is given as object, it will be used as it is without doing any encoding. But if URL is given as string, it will be encoded by Node while converting it to object.
 - `time` - if `true`, the request-response cycle (including all redirects) is timed at millisecond resolution. When set, the following properties are added to the response object:
   - `elapsedTime` Duration of the entire request/response in milliseconds (*deprecated*).
   - `responseStartTime` Timestamp when the response began (in Unix Epoch milliseconds) (*deprecated*).

--- a/request.js
+++ b/request.js
@@ -848,7 +848,7 @@ Request.prototype.start = function () {
   delete reqOptions.auth
 
   // Workaround for a bug in Node: https://github.com/nodejs/node/issues/8321
-  if (!(self.disablePostmanUrlEncoder || self.proxy || self.uri.isUnix)) {
+  if (!(self.disableUrlEncoding || self.proxy || self.uri.isUnix)) {
     try {
       extend(reqOptions, urlParse(self.uri.href))
     } catch (e) { } // nothing to do if urlParse fails, "extend" never throws an error.

--- a/request.js
+++ b/request.js
@@ -848,7 +848,7 @@ Request.prototype.start = function () {
   delete reqOptions.auth
 
   // Workaround for a bug in Node: https://github.com/nodejs/node/issues/8321
-  if (!self.proxy && !(self.uri.isUnix)) {
+  if (!(self.disablePostmanUrlEncoder || self.proxy || self.uri.isUnix)) {
     try {
       extend(reqOptions, urlParse(self.uri.href))
     } catch (e) { } // nothing to do if urlParse fails, "extend" never throws an error.

--- a/tests/test-disablePostmanUrlEncoder.js
+++ b/tests/test-disablePostmanUrlEncoder.js
@@ -32,7 +32,7 @@ tape('setup', function (t) {
   })
 })
 
-tape('UTF-8 URL without disablePostmanUrlEncoder option', function (t) {
+tape('UTF-8 URL without disableUrlEncoding option', function (t) {
   var requestUrl = 'http://localhost:' + plainServer.port + '/query?邮=差'
 
   request(requestUrl, function (err, res, body) {
@@ -42,7 +42,7 @@ tape('UTF-8 URL without disablePostmanUrlEncoder option', function (t) {
   })
 })
 
-tape('URL containing character \'!\' without disablePostmanUrlEncoder option', function (t) {
+tape('URL containing character \'!\' without disableUrlEncoding option', function (t) {
   var requestUrl = 'http://localhost:' + plainServer.port + '/query?!foo!=!bar!'
 
   request(requestUrl, function (err, res, body) {
@@ -52,7 +52,7 @@ tape('URL containing character \'!\' without disablePostmanUrlEncoder option', f
   })
 })
 
-tape('Encoded UTF-8 URL in redirect without disablePostmanUrlEncoder option', function (t) {
+tape('Encoded UTF-8 URL in redirect without disableUrlEncoding option', function (t) {
   var requestUrl = 'http://localhost:' + plainServer.port + '/redirect'
 
   request(requestUrl, function (err, res, body) {
@@ -62,7 +62,7 @@ tape('Encoded UTF-8 URL in redirect without disablePostmanUrlEncoder option', fu
   })
 })
 
-tape('URL containing character \'!\' in redirect without disablePostmanUrlEncoder option', function (t) {
+tape('URL containing character \'!\' in redirect without disableUrlEncoding option', function (t) {
   var requestUrl = 'http://localhost:' + plainServer.port + '/redirect2'
 
   request(requestUrl, function (err, res, body) {
@@ -72,11 +72,11 @@ tape('URL containing character \'!\' in redirect without disablePostmanUrlEncode
   })
 })
 
-tape('Encoded UTF-8 URL with disablePostmanUrlEncoder=true option', function (t) {
+tape('Encoded UTF-8 URL with disableUrlEncoding=true option', function (t) {
   // given URL should be pre-encoded because encoder is disabled. So the request will fail otherwise
   var requestUrl = 'http://localhost:' + plainServer.port + '/query?%E9%82%AE=%E5%B7%AE'
   var options = {
-    disablePostmanUrlEncoder: true
+    disableUrlEncoding: true
   }
 
   request(requestUrl, options, function (err, res, body) {
@@ -86,9 +86,9 @@ tape('Encoded UTF-8 URL with disablePostmanUrlEncoder=true option', function (t)
   })
 })
 
-tape('URL containing character \'!\' with disablePostmanUrlEncoder=true option', function (t) {
+tape('URL containing character \'!\' with disableUrlEncoding=true option', function (t) {
   var requestUrl = 'http://localhost:' + plainServer.port + '/query?!foo!=!bar!'
-  var options = { disablePostmanUrlEncoder: true }
+  var options = { disableUrlEncoding: true }
 
   request(requestUrl, options, function (err, res, body) {
     t.equal(err, null)
@@ -97,11 +97,11 @@ tape('URL containing character \'!\' with disablePostmanUrlEncoder=true option',
   })
 })
 
-tape('Encoded UTF-8 URL in redirect with disablePostmanUrlEncoder=true option', function (t) {
+tape('Encoded UTF-8 URL in redirect with disableUrlEncoding=true option', function (t) {
   // given URL should be pre-encoded because encoder is disabled. So the request will fail otherwise
   var requestUrl = 'http://localhost:' + plainServer.port + '/query?%E9%82%AE=%E5%B7%AE'
   var options = {
-    disablePostmanUrlEncoder: true
+    disableUrlEncoding: true
   }
 
   request(requestUrl, options, function (err, res, body) {
@@ -111,9 +111,9 @@ tape('Encoded UTF-8 URL in redirect with disablePostmanUrlEncoder=true option', 
   })
 })
 
-tape('URL with character \'!\' in redirect with disablePostmanUrlEncoder=true option', function (t) {
+tape('URL with character \'!\' in redirect with disableUrlEncoding=true option', function (t) {
   var requestUrl = 'http://localhost:' + plainServer.port + '/redirect2'
-  var options = { disablePostmanUrlEncoder: true }
+  var options = { disableUrlEncoding: true }
 
   request(requestUrl, options, function (err, res, body) {
     t.equal(err, null)
@@ -122,9 +122,9 @@ tape('URL with character \'!\' in redirect with disablePostmanUrlEncoder=true op
   })
 })
 
-tape('UTF-8 URL with disablePostmanUrlEncoder=true option', function (t) {
+tape('UTF-8 URL with disableUrlEncoding=true option', function (t) {
   var requestUrl = 'http://localhost:' + plainServer.port + '/query?邮=差'
-  var options = { disablePostmanUrlEncoder: true }
+  var options = { disableUrlEncoding: true }
 
   // this request should fail because encoding is off and URL contains UTF-8 characters
   request(requestUrl, options, function (err, res, body) {

--- a/tests/test-disablePostmanUrlEncoder.js
+++ b/tests/test-disablePostmanUrlEncoder.js
@@ -1,4 +1,3 @@
-var url = require('url')
 var tape = require('tape')
 var server = require('./server')
 var request = require('../index')
@@ -126,7 +125,7 @@ tape('URL with character \'!\' in redirect with disablePostmanUrlEncoder=true op
 tape('UTF-8 URL with disablePostmanUrlEncoder=true option', function (t) {
   var requestUrl = 'http://localhost:' + plainServer.port + '/query?邮=差'
   var options = { disablePostmanUrlEncoder: true }
-  
+
   // this request should fail because encoding is off and URL contains UTF-8 characters
   request(requestUrl, options, function (err, res, body) {
     t.notEqual(err, null)

--- a/tests/test-disablePostmanUrlEncoder.js
+++ b/tests/test-disablePostmanUrlEncoder.js
@@ -1,0 +1,142 @@
+var url = require('url')
+var tape = require('tape')
+var server = require('./server')
+var request = require('../index')
+var destroyable = require('server-destroy')
+
+var plainServer = server.createServer()
+
+destroyable(plainServer)
+
+tape('setup', function (t) {
+  plainServer.listen(0, function () {
+    plainServer.on('/query', function (req, res) {
+      res.writeHead(200)
+      res.end(req.url)
+    })
+
+    plainServer.on('/redirect', function (req, res) {
+      res.writeHead(301, {
+        'Location': 'http://localhost:' + plainServer.port + '/query?%E9%82%AE=%E5%B7%AE'
+      })
+      res.end()
+    })
+
+    plainServer.on('/redirect2', function (req, res) {
+      res.writeHead(301, {
+        'Location': 'http://localhost:' + plainServer.port + '/query?!foo!=!bar!'
+      })
+      res.end()
+    })
+
+    t.end()
+  })
+})
+
+tape('UTF-8 URL without disablePostmanUrlEncoder option', function (t) {
+  var requestUrl = 'http://localhost:' + plainServer.port + '/query?邮=差'
+
+  request(requestUrl, function (err, res, body) {
+    t.equal(err, null)
+    t.equal(body, '/query?%E9%82%AE=%E5%B7%AE')
+    t.end()
+  })
+})
+
+tape('URL containing character \'!\' without disablePostmanUrlEncoder option', function (t) {
+  var requestUrl = 'http://localhost:' + plainServer.port + '/query?!foo!=!bar!'
+
+  request(requestUrl, function (err, res, body) {
+    t.equal(err, null)
+    t.equal(body, '/query?%21foo%21=%21bar%21')
+    t.end()
+  })
+})
+
+tape('Encoded UTF-8 URL in redirect without disablePostmanUrlEncoder option', function (t) {
+  var requestUrl = 'http://localhost:' + plainServer.port + '/redirect'
+
+  request(requestUrl, function (err, res, body) {
+    t.equal(err, null)
+    t.equal(body, '/query?%E9%82%AE=%E5%B7%AE')
+    t.end()
+  })
+})
+
+tape('URL containing character \'!\' in redirect without disablePostmanUrlEncoder option', function (t) {
+  var requestUrl = 'http://localhost:' + plainServer.port + '/redirect2'
+
+  request(requestUrl, function (err, res, body) {
+    t.equal(err, null)
+    t.equal(body, '/query?%21foo%21=%21bar%21')
+    t.end()
+  })
+})
+
+tape('Encoded UTF-8 URL with disablePostmanUrlEncoder=true option', function (t) {
+  // given URL should be pre-encoded because encoder is disabled. So the request will fail otherwise
+  var requestUrl = 'http://localhost:' + plainServer.port + '/query?%E9%82%AE=%E5%B7%AE'
+  var options = {
+    disablePostmanUrlEncoder: true
+  }
+
+  request(requestUrl, options, function (err, res, body) {
+    t.equal(err, null)
+    t.equal(body, '/query?%E9%82%AE=%E5%B7%AE')
+    t.end()
+  })
+})
+
+tape('URL containing character \'!\' with disablePostmanUrlEncoder=true option', function (t) {
+  var requestUrl = 'http://localhost:' + plainServer.port + '/query?!foo!=!bar!'
+  var options = { disablePostmanUrlEncoder: true }
+
+  request(requestUrl, options, function (err, res, body) {
+    t.equal(err, null)
+    t.equal(body, '/query?!foo!=!bar!')
+    t.end()
+  })
+})
+
+tape('Encoded UTF-8 URL in redirect with disablePostmanUrlEncoder=true option', function (t) {
+  // given URL should be pre-encoded because encoder is disabled. So the request will fail otherwise
+  var requestUrl = 'http://localhost:' + plainServer.port + '/query?%E9%82%AE=%E5%B7%AE'
+  var options = {
+    disablePostmanUrlEncoder: true
+  }
+
+  request(requestUrl, options, function (err, res, body) {
+    t.equal(err, null)
+    t.equal(body, '/query?%E9%82%AE=%E5%B7%AE')
+    t.end()
+  })
+})
+
+tape('URL with character \'!\' in redirect with disablePostmanUrlEncoder=true option', function (t) {
+  var requestUrl = 'http://localhost:' + plainServer.port + '/redirect2'
+  var options = { disablePostmanUrlEncoder: true }
+
+  request(requestUrl, options, function (err, res, body) {
+    t.equal(err, null)
+    t.equal(body, '/query?!foo!=!bar!')
+    t.end()
+  })
+})
+
+tape('UTF-8 URL with disablePostmanUrlEncoder=true option', function (t) {
+  var requestUrl = 'http://localhost:' + plainServer.port + '/query?邮=差'
+  var options = { disablePostmanUrlEncoder: true }
+  
+  // this request should fail because encoding is off and URL contains UTF-8 characters
+  request(requestUrl, options, function (err, res, body) {
+    t.notEqual(err, null)
+    t.equal(body, undefined)
+    t.end()
+  })
+})
+
+tape('cleanup', function (t) {
+  plainServer.destroy(function () {
+    t.end()
+  })
+})


### PR DESCRIPTION
## PR Checklist:
- [x] I have run `npm test` locally and all tests are passing.
- [x] I have added/updated tests for any new behavior.
- [ ] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A]

## PR Description
Add disablePostmanUrlEncoder option which will prevent postman-url-encoder to encode given URL for the request.
