### PR TITLE
Use Title-Case names when setting headers

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -136,7 +136,7 @@ Auth.prototype.onRequest = function (user, pass, sendImmediately, bearer) {
     authHeader = self.basic(user, pass, sendImmediately)
   }
   if (authHeader) {
-    request.setHeader('authorization', authHeader)
+    request.setHeader('Authorization', authHeader)
   }
 }
 

--- a/lib/multipart.js
+++ b/lib/multipart.js
@@ -47,18 +47,18 @@ Multipart.prototype.setHeaders = function (chunked) {
   var self = this
 
   if (chunked && !self.request.hasHeader('transfer-encoding')) {
-    self.request.setHeader('transfer-encoding', 'chunked')
+    self.request.setHeader('Transfer-Encoding', 'chunked')
   }
 
   var header = self.request.getHeader('content-type')
 
   if (!header || header.indexOf('multipart') === -1) {
-    self.request.setHeader('content-type', 'multipart/related; boundary=' + self.boundary)
+    self.request.setHeader('Content-Type', 'multipart/related; boundary=' + self.boundary)
   } else {
     if (header.indexOf('boundary') !== -1) {
       self.boundary = header.replace(/.*boundary=([^\s;]+).*/, '$1')
     } else {
-      self.request.setHeader('content-type', header + '; boundary=' + self.boundary)
+      self.request.setHeader('Content-Type', header + '; boundary=' + self.boundary)
     }
   }
 }

--- a/lib/redirect.js
+++ b/lib/redirect.js
@@ -77,7 +77,7 @@ Redirect.prototype.redirectTo = function (response) {
     // https://tools.ietf.org/html/rfc7235#section-3.1
     var authHeader = request._auth.onResponse(response)
     if (authHeader) {
-      request.setHeader('authorization', authHeader)
+      request.setHeader('Authorization', authHeader)
       redirectTo = request.uri
     }
   }
@@ -200,7 +200,7 @@ Redirect.prototype.onResponse = function (response) {
   }
 
   if (!self.removeRefererHeader) {
-    request.setHeader('referer', uriPrev.href)
+    request.setHeader('Referer', uriPrev.href)
   }
 
   request.emit('redirect')

--- a/request.js
+++ b/request.js
@@ -444,7 +444,7 @@ Request.prototype.init = function (options) {
   }
 
   if (self.gzip && !self.hasHeader('accept-encoding')) {
-    self.setHeader('accept-encoding', 'gzip, deflate')
+    self.setHeader('Accept-Encoding', 'gzip, deflate')
   }
 
   if (self.uri.auth && !self.hasHeader('authorization')) {
@@ -455,7 +455,7 @@ Request.prototype.init = function (options) {
   if (!self.tunnel && self.proxy && self.proxy.auth && !self.hasHeader('proxy-authorization')) {
     var proxyAuthPieces = self.proxy.auth.split(':').map(function (item) { return self._qs.unescape(item) })
     var authHeader = 'Basic ' + toBase64(proxyAuthPieces.join(':'))
-    self.setHeader('proxy-authorization', authHeader)
+    self.setHeader('Proxy-Authorization', authHeader)
   }
 
   if (self.proxy && !self.tunnel) {
@@ -501,7 +501,7 @@ Request.prototype.init = function (options) {
       }
 
       if (length) {
-        self.setHeader('content-length', length)
+        self.setHeader('Content-Length', length)
       } else {
         self.emit('error', new Error('Argument error, options.body.'))
       }
@@ -567,7 +567,7 @@ Request.prototype.init = function (options) {
     self.src = src
     if (isReadStream(src)) {
       if (!self.hasHeader('content-type')) {
-        self.setHeader('content-type', mime.lookup(src.path))
+        self.setHeader('Content-Type', mime.lookup(src.path))
       }
     } else {
       if (src.headers) {
@@ -578,7 +578,7 @@ Request.prototype.init = function (options) {
         }
       }
       if (self._json && !self.hasHeader('content-type')) {
-        self.setHeader('content-type', 'application/json')
+        self.setHeader('Content-Type', 'application/json')
       }
       if (src.method && !self.explicitMethod) {
         self.method = src.method
@@ -617,7 +617,7 @@ Request.prototype.init = function (options) {
           } else { // certain servers require content-length to function. we try to pre-detect if possible
             streamLength(self.body, {}, function (err, len) {
               if (!(err || self._started || self.hasHeader('content-length') || len === null || len < 0)) {
-                self.setHeader('content-length', len)
+                self.setHeader('Content-Length', len)
               }
               self.body.pipe(self)
             })
@@ -642,7 +642,7 @@ Request.prototype.init = function (options) {
           return
         }
         if (self.method !== 'GET' && typeof self.method !== 'undefined') {
-          self.setHeader('content-length', 0)
+          self.setHeader('Content-Length', 0)
         }
         self.end()
       }
@@ -653,7 +653,7 @@ Request.prototype.init = function (options) {
       self.setHeader(self._form.getHeaders(), true)
       self._form.getLength(function (err, length) {
         if (!err && !isNaN(length)) {
-          self.setHeader('content-length', length)
+          self.setHeader('Content-Length', length)
         }
         end()
       })
@@ -833,7 +833,7 @@ Request.prototype.start = function () {
   self.href = self.uri.href
 
   if (self.src && self.src.stat && self.src.stat.size && !self.hasHeader('content-length')) {
-    self.setHeader('content-length', self.src.stat.size)
+    self.setHeader('Content-Length', self.src.stat.size)
   }
   if (self._aws) {
     self.aws(self._aws, true)
@@ -1494,7 +1494,7 @@ Request.prototype.form = function (form) {
   var self = this
   if (form) {
     if (!/^application\/x-www-form-urlencoded\b/.test(self.getHeader('content-type'))) {
-      self.setHeader('content-type', 'application/x-www-form-urlencoded')
+      self.setHeader('Content-Type', 'application/x-www-form-urlencoded')
     }
     self.body = (typeof form === 'string')
       ? self._qs.rfc3986(form.toString('utf8'))
@@ -1525,7 +1525,7 @@ Request.prototype.json = function (val) {
   var self = this
 
   if (!self.hasHeader('accept')) {
-    self.setHeader('accept', 'application/json')
+    self.setHeader('Accept', 'application/json')
   }
 
   if (typeof self.jsonReplacer === 'function') {
@@ -1541,13 +1541,13 @@ Request.prototype.json = function (val) {
         self.body = self._qs.rfc3986(self.body)
       }
       if (!self.hasHeader('content-type')) {
-        self.setHeader('content-type', 'application/json')
+        self.setHeader('Content-Type', 'application/json')
       }
     }
   } else {
     self.body = safeStringify(val, self._jsonReplacer)
     if (!self.hasHeader('content-type')) {
-      self.setHeader('content-type', 'application/json')
+      self.setHeader('Content-Type', 'application/json')
     }
   }
 
@@ -1621,15 +1621,15 @@ Request.prototype.aws = function (opts, now) {
       secretAccessKey: opts.secret,
       sessionToken: opts.session
     })
-    self.setHeader('authorization', signRes.headers.Authorization)
-    self.setHeader('x-amz-date', signRes.headers['X-Amz-Date'])
+    self.setHeader('Authorization', signRes.headers.Authorization)
+    self.setHeader('X-Amz-Date', signRes.headers['X-Amz-Date'])
     if (signRes.headers['X-Amz-Security-Token']) {
-      self.setHeader('x-amz-security-token', signRes.headers['X-Amz-Security-Token'])
+      self.setHeader('X-Amz-Security-Token', signRes.headers['X-Amz-Security-Token'])
     }
   } else {
     // default: use aws-sign2
     var date = new Date()
-    self.setHeader('date', date.toUTCString())
+    self.setHeader('Date', date.toUTCString())
     var auth = {
       key: opts.key,
       secret: opts.secret,
@@ -1650,7 +1650,7 @@ Request.prototype.aws = function (opts, now) {
       auth.resource = '/'
     }
     auth.resource = aws2.canonicalizeResource(auth.resource)
-    self.setHeader('authorization', aws2.authorization(auth))
+    self.setHeader('Authorization', aws2.authorization(auth))
   }
 
   return self
@@ -1708,9 +1708,9 @@ Request.prototype.jar = function (jar) {
   if (cookies && cookies.length) {
     if (self.originalCookieHeader) {
       // Don't overwrite existing Cookie header
-      self.setHeader('cookie', self.originalCookieHeader + '; ' + cookies)
+      self.setHeader('Cookie', self.originalCookieHeader + '; ' + cookies)
     } else {
-      self.setHeader('cookie', cookies)
+      self.setHeader('Cookie', cookies)
     }
   }
   self._jar = jar

--- a/request.js
+++ b/request.js
@@ -356,7 +356,7 @@ Request.prototype.init = function (options) {
 
   self.setHost = false
   if (!self.hasHeader('host')) {
-    var hostHeaderName = self.originalHostHeaderName || 'host'
+    var hostHeaderName = self.originalHostHeaderName || 'Host'
     self.setHeader(hostHeaderName, self.uri.host)
     // Drop :port suffix from Host header if known protocol.
     if (self.uri.port) {
@@ -648,9 +648,11 @@ Request.prototype.init = function (options) {
       }
     }
 
+    // @todo what if Content-Length is present but Content-Type is not set?
     if (self._form && !self.hasHeader('content-length')) {
       // Before ending the request, we had to compute the length of the whole form, asyncly
-      self.setHeader(self._form.getHeaders(), true)
+      // @todo don't override Content-Type if already set
+      self.setHeader('Content-Type', 'multipart/form-data; boundary=' + self._form.getBoundary())
       self._form.getLength(function (err, length) {
         if (!err && !isNaN(length)) {
           self.setHeader('Content-Length', length)

--- a/tests/test-proxy-connect.js
+++ b/tests/test-proxy-connect.js
@@ -65,7 +65,7 @@ tape('proxy', function (t) {
       'dont-send-to-proxy: ok',
       'accept: yo',
       'user-agent: just another foobar',
-      'host: google.com'
+      'Host: google.com'
     ].join('\r\n'))
     t.equal(true, re.test(data))
     t.equal(called, true, 'the request must be made to the proxy server')

--- a/tests/test-redirect.js
+++ b/tests/test-redirect.js
@@ -429,7 +429,7 @@ tape('should have referer header by default when following redirect', function (
     t.end()
   })
   .on('redirect', function () {
-    t.equal(this.headers['Referer'], s.url + '/temp')
+    t.equal(this.headers.Referer, s.url + '/temp')
   })
 })
 
@@ -446,7 +446,7 @@ tape('should not have referer header when removeRefererHeader is true', function
     t.end()
   })
   .on('redirect', function () {
-    t.equal(this.headers['Referer'], undefined)
+    t.equal(this.headers.Referer, undefined)
   })
 })
 
@@ -463,7 +463,7 @@ tape('should preserve referer header set in the initial request when removeRefer
     t.end()
   })
   .on('redirect', function () {
-    t.equal(this.headers['referer'], 'http://awesome.com')
+    t.equal(this.headers.referer, 'http://awesome.com')
   })
 })
 

--- a/tests/test-redirect.js
+++ b/tests/test-redirect.js
@@ -429,7 +429,7 @@ tape('should have referer header by default when following redirect', function (
     t.end()
   })
   .on('redirect', function () {
-    t.equal(this.headers.referer, s.url + '/temp')
+    t.equal(this.headers['Referer'], s.url + '/temp')
   })
 })
 
@@ -446,7 +446,7 @@ tape('should not have referer header when removeRefererHeader is true', function
     t.end()
   })
   .on('redirect', function () {
-    t.equal(this.headers.referer, undefined)
+    t.equal(this.headers['Referer'], undefined)
   })
 })
 
@@ -463,7 +463,7 @@ tape('should preserve referer header set in the initial request when removeRefer
     t.end()
   })
   .on('redirect', function () {
-    t.equal(this.headers.referer, 'http://awesome.com')
+    t.equal(this.headers['referer'], 'http://awesome.com')
   })
 })
 


### PR DESCRIPTION
## PR Checklist:
- [x] I have run `npm test` locally and all tests are passing.
- [x] I have added/updated tests for any new behavior.
       <!-- Request is a complex project, there are VERY FEW exceptions
               where a new test is not required for new behavior. -->
- [x] If this is a significant change, an issue has already been created where the problem / solution was discussed: [#6414](https://github.com/postmanlabs/postman-app-support/issues/6414)
       <!-- If you'd like to suggest a significant change to request,
               please create an issue to discuss those changes and gather
               feedback BEFORE submitting your PR. -->


## PR Description
<!-- Describe Your PR Here! -->

When setting headers, `postman-request` added headers in lowercase. Change all `setHeader` call header name arguments from lowercase to TitleCase to preserve consistency.

This change does not change case for the headers which are already present in the request/response i.e. if a node sent headers in lowercase, they are kept that way.