### PR TITLE
Prevent `Content-Type` override if `Content-Length` not set

### DIFF
--- a/request.js
+++ b/request.js
@@ -648,11 +648,12 @@ Request.prototype.init = function (options) {
       }
     }
 
-    // @todo what if Content-Length is present but Content-Type is not set?
+    if (self._form && !self.hasHeader('content-type')) {
+      self.setHeader('Content-Type', 'multipart/form-data; boundary=' + self._form.getBoundary())
+    }
+
     if (self._form && !self.hasHeader('content-length')) {
       // Before ending the request, we had to compute the length of the whole form, asyncly
-      // @todo don't override Content-Type if already set
-      self.setHeader('Content-Type', 'multipart/form-data; boundary=' + self._form.getBoundary())
       self._form.getLength(function (err, length) {
         if (!err && !isNaN(length)) {
           self.setHeader('Content-Length', length)

--- a/tests/test-form-data-boundary.js
+++ b/tests/test-form-data-boundary.js
@@ -91,7 +91,7 @@ tape('custom boundary within quotes', function (t) {
     var req = JSON.parse(body)
     t.equal(err, null)
     t.equal(res.statusCode, 200)
-    t.equal(req.headers['content-type'], 'multipart/form-data; boundary=' + boundary)
+    t.equal(req.headers['content-type'], 'multipart/form-data; boundary="' + boundary + '"')
     t.ok(req.body.startsWith('--' + boundary))
     t.ok(req.body.indexOf('name="formKey"') !== -1)
     t.ok(req.body.indexOf('formValue') !== -1)
@@ -105,8 +105,6 @@ tape('custom boundary with content-length', function (t) {
   request.post({
     url: server.url,
     headers: {
-      // @note `content-type` header is not re-calculated if `content-length`
-      // is present for formData body
       'content-type': 'multipart/anything; boundary=' + boundary,
       'content-length': '111'
     },
@@ -119,6 +117,29 @@ tape('custom boundary with content-length', function (t) {
     t.equal(res.statusCode, 200)
     t.equal(req.headers['content-type'], 'multipart/anything; boundary=' + boundary)
     t.equal(req.headers['content-length'], '111')
+    t.ok(req.body.startsWith('--' + boundary))
+    t.ok(req.body.indexOf('name="formKey"') !== -1)
+    t.ok(req.body.indexOf('formValue') !== -1)
+    t.ok(req.body.endsWith(boundary + '--\r\n'))
+    t.end()
+  })
+})
+
+tape('custom boundary and charset', function (t) {
+  var boundary = '----WebKitFormBoundary7MA4YWxkTrZu0gW'
+  request.post({
+    url: server.url,
+    headers: {
+      'content-type': 'multipart/form-data; charset=UTF-8; boundary=' + boundary
+    },
+    formData: {
+      formKey: 'formValue'
+    }
+  }, function (err, res, body) {
+    var req = JSON.parse(body)
+    t.equal(err, null)
+    t.equal(res.statusCode, 200)
+    t.equal(req.headers['content-type'], 'multipart/form-data; charset=UTF-8; boundary=' + boundary)
     t.ok(req.body.startsWith('--' + boundary))
     t.ok(req.body.indexOf('name="formKey"') !== -1)
     t.ok(req.body.indexOf('formValue') !== -1)

--- a/tests/test-form-data-boundary.js
+++ b/tests/test-form-data-boundary.js
@@ -100,6 +100,30 @@ tape('custom boundary within quotes', function (t) {
   })
 })
 
+tape('content-length without content-type', function (t) {
+  request.post({
+    url: server.url,
+    headers: {
+      'content-length': '171'
+    },
+    formData: {
+      formKey: 'formValue'
+    }
+  }, function (err, res, body) {
+    var req = JSON.parse(body)
+    var boundary
+    t.equal(err, null)
+    t.equal(res.statusCode, 200)
+    t.notEqual(req.headers['content-type'], null)
+    boundary = req.headers['content-type'].split('boundary=')[1]
+    t.equal(req.headers['content-type'], 'multipart/form-data; boundary=' + boundary)
+    t.equal(req.headers['content-length'], '171')
+    t.ok(req.body.indexOf('name="formKey"') !== -1)
+    t.ok(req.body.indexOf('formValue') !== -1)
+    t.end()
+  })
+})
+
 tape('custom boundary with content-length', function (t) {
   var boundary = 'X-FORM-DATA-BOUNDARY'
   request.post({
@@ -126,7 +150,7 @@ tape('custom boundary with content-length', function (t) {
 })
 
 tape('custom boundary and charset', function (t) {
-  var boundary = '----WebKitFormBoundary7MA4YWxkTrZu0gW'
+  var boundary = 'X-FORM-DATA-BOUNDARY'
   request.post({
     url: server.url,
     headers: {

--- a/tests/test-form-data-boundary.js
+++ b/tests/test-form-data-boundary.js
@@ -118,6 +118,8 @@ tape('content-length without content-type', function (t) {
     boundary = req.headers['content-type'].split('boundary=')[1]
     t.equal(req.headers['content-type'], 'multipart/form-data; boundary=' + boundary)
     t.equal(req.headers['content-length'], '171')
+    t.ok(req.body.startsWith('--' + boundary))
+    t.ok(req.body.endsWith(boundary + '--\r\n'))
     t.ok(req.body.indexOf('name="formKey"') !== -1)
     t.ok(req.body.indexOf('formValue') !== -1)
     t.end()


### PR DESCRIPTION
## PR Checklist:
- [x] I have run `npm test` locally and all tests are passing.
- [x] I have added/updated tests for any new behavior.
       <!-- Request is a complex project, there are VERY FEW exceptions
               where a new test is not required for new behavior. -->
- [x] If this is a significant change, an issue has already been created where the problem / solution was discussed: https://github.com/postmanlabs/postman-app-support/issues/1392
       <!-- If you'd like to suggest a significant change to request,
               please create an issue to discuss those changes and gather
               feedback BEFORE submitting your PR. -->


## PR Description
<!-- Describe Your PR Here! -->

`Content-Type` was re-written if `Content-Length` was not present. This change prevents that behaviour. Also adds test for specifying custom charset in the `Content-Type` header.