### PR TITLE
Handle multiple `cookie` headers with jar

### DIFF
--- a/request.js
+++ b/request.js
@@ -1747,6 +1747,9 @@ Request.prototype.jar = function (jar, cb) {
     // if need cookie and cookie is not empty
     if (cookies && cookies.length) {
       if (self.originalCookieHeader) {
+        if (Array.isArray(self.originalCookieHeader)) {
+          self.originalCookieHeader = self.originalCookieHeader.join('; ')
+        }
         // Don't overwrite existing Cookie header
         self.setHeader('Cookie', self.originalCookieHeader + '; ' + cookies)
       } else {

--- a/tests/test-headers.js
+++ b/tests/test-headers.js
@@ -62,13 +62,14 @@ function addTests () {
     })
 
   var jar = request.jar()
-  jar.setCookieSync('quux=baz', s.url)
+  jar.setCookieSync('c1=v1', s.url)
+  jar.setCookieSync('c2=v2', s.url)
   runTest(
     '#125: headers.cookie + cookie jar',
     'header-and-jar',
-    {jar: jar, headers: {cookie: 'foo=bar'}},
+    {jar: jar, headers: {cookie: ['c3=v3', 'c4=v4']}},
     function (t, req, res) {
-      t.equal(req.headers.cookie, 'foo=bar; quux=baz')
+      t.equal(req.headers.cookie, 'c3=v3; c4=v4; c1=v1; c2=v2')
     })
 
   var jar2 = request.jar()


### PR DESCRIPTION
## PR Checklist:
- [x] I have run `npm test` locally and all tests are passing.
- [x] I have added/updated tests for any new behavior.
       <!-- Request is a complex project, there are VERY FEW exceptions
               where a new test is not required for new behavior. -->
- [x] If this is a significant change, an issue has already been created where the problem / solution was discussed: https://github.com/postmanlabs/postman-app-support/issues/5076
       <!-- If you'd like to suggest a significant change to request,
               please create an issue to discuss those changes and gather
               feedback BEFORE submitting your PR. -->


## PR Description
Correctly generate `cookie` header if multiple `cookie` headers are present as well as cookies present in the cookie jar.

Previously: `Cookie: c3=v3,c4=v4; c1=v1; c2=v2`
Now: `Cookie: c3=v3; c4=v4; c1=v1; c2=v2`