### PR TITLE
Fix the crash when proxy server sends a response

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "safe-buffer": "^5.1.2",
     "stream-length": "^1.0.2",
     "tough-cookie": "~2.5.0",
-    "@postman/tunnel-agent": "^0.6.2",
+    "@postman/tunnel-agent": "^0.6.3",
     "uuid": "^3.3.2"
   },
   "scripts": {

--- a/tests/test-tunnel-response.js
+++ b/tests/test-tunnel-response.js
@@ -1,0 +1,488 @@
+'use strict'
+
+// @note The proxy server in this test file sends a response body for the
+// `CONNECT` request.  The RFC says that the `CONNECT` response does not have a
+// response body, but some proxy servers might be sending it anyway. Here we
+// ensure that we can handle this case.
+
+var server = require('./server')
+var tape = require('tape')
+var request = require('../index')
+var https = require('https')
+var net = require('net')
+var fs = require('fs')
+var path = require('path')
+var util = require('util')
+var url = require('url')
+var destroyable = require('server-destroy')
+
+var events = []
+var caFile = path.resolve(__dirname, 'ssl/ca/ca.crt')
+var ca = fs.readFileSync(caFile)
+var clientCert = fs.readFileSync(path.resolve(__dirname, 'ssl/ca/client.crt'))
+var clientKey = fs.readFileSync(path.resolve(__dirname, 'ssl/ca/client-enc.key'))
+var invalidClientKey = fs.readFileSync(path.resolve(__dirname, 'ssl/ca/localhost.key'))
+var clientPassword = 'password'
+var sslOpts = {
+  key: path.resolve(__dirname, 'ssl/ca/localhost.key'),
+  cert: path.resolve(__dirname, 'ssl/ca/localhost.crt')
+}
+
+var mutualSSLOpts = {
+  key: path.resolve(__dirname, 'ssl/ca/localhost.key'),
+  cert: path.resolve(__dirname, 'ssl/ca/localhost.crt'),
+  ca: caFile,
+  requestCert: true,
+  rejectUnauthorized: true
+}
+
+// this is needed for 'https over http, tunnel=false' test
+// from https://github.com/coolaj86/node-ssl-root-cas/blob/v1.1.9-beta/ssl-root-cas.js#L4267-L4281
+var httpsOpts = https.globalAgent.options
+httpsOpts.ca = httpsOpts.ca || []
+httpsOpts.ca.push(ca)
+
+var s = server.createServer()
+var ss = server.createSSLServer(sslOpts)
+var ss2 = server.createSSLServer(mutualSSLOpts)
+
+// XXX when tunneling https over https, connections get left open so the server
+// doesn't want to close normally (and same issue with http server on v0.8.x)
+destroyable(s)
+destroyable(ss)
+destroyable(ss2)
+
+function event () {
+  events.push(util.format.apply(null, arguments))
+}
+
+function setListeners (server, type) {
+  server.on('/', function (req, res) {
+    event('%s response', type)
+    res.end(type + ' ok')
+  })
+
+  server.on('request', function (req, res) {
+    if (/^https?:/.test(req.url)) {
+      // This is a proxy request
+      var dest = req.url.split(':')[0]
+      // Is it a redirect?
+      var match = req.url.match(/\/redirect\/(https?)$/)
+      if (match) {
+        dest += '->' + match[1]
+      }
+      event('%s proxy to %s', type, dest)
+      request(req.url, { followRedirect: false }).pipe(res)
+    }
+  })
+
+  server.on('/redirect/http', function (req, res) {
+    event('%s redirect to http', type)
+    res.writeHead(301, {
+      location: s.url
+    })
+    res.end()
+  })
+
+  server.on('/redirect/https', function (req, res) {
+    event('%s redirect to https', type)
+    res.writeHead(301, {
+      location: ss.url
+    })
+    res.end()
+  })
+
+  server.on('connect', function (req, client, head) {
+    var u = url.parse(req.url)
+    var server = net.connect(u.host, u.port, function () {
+      event('%s connect to %s', type, req.url)
+      client.write('HTTP/1.1 200 Connection established\r\n' +
+        'Proxy-Agent: postman-proxy-agent\r\n' +
+        '\r\n' +
+        'OK')
+      client.pipe(server)
+      server.write(head)
+      server.pipe(client)
+    })
+  })
+}
+
+setListeners(s, 'http')
+setListeners(ss, 'https')
+setListeners(ss2, 'https')
+
+// monkey-patch since you can't set a custom certificate authority for the
+// proxy in tunnel-agent (this is necessary for "* over https" tests)
+var customCaCount = 0
+var httpsRequestOld = https.request
+https.request = function (options) {
+  if (customCaCount) {
+    options.ca = ca
+    customCaCount--
+  }
+  return httpsRequestOld.apply(this, arguments)
+}
+
+function runTest (name, opts, expected) {
+  tape(name, function (t) {
+    opts.ca = ca
+    if (opts.proxy === ss.url) {
+      customCaCount = (opts.url === ss.url ? 2 : 1)
+    }
+    request(opts, function (err, res, body) {
+      event(err ? 'err ' + err.message : res.statusCode + ' ' + body)
+      t.deepEqual(events, expected)
+      events = []
+      t.end()
+    })
+  })
+}
+
+function addTests () {
+  // HTTP OVER HTTP
+
+  runTest('http over http, tunnel=true, with proxy response', {
+    url: s.url,
+    proxy: s.url,
+    tunnel: true
+  }, [
+    'http connect to localhost:' + s.port,
+    'http response',
+    '200 http ok'
+  ])
+
+  runTest('http over http, tunnel=false, with proxy response', {
+    url: s.url,
+    proxy: s.url,
+    tunnel: false
+  }, [
+    'http proxy to http',
+    'http response',
+    '200 http ok'
+  ])
+
+  runTest('http over http, tunnel=default, with proxy response', {
+    url: s.url,
+    proxy: s.url
+  }, [
+    'http proxy to http',
+    'http response',
+    '200 http ok'
+  ])
+
+  // HTTP OVER HTTPS
+
+  runTest('http over https, tunnel=true, with proxy response', {
+    url: s.url,
+    proxy: ss.url,
+    tunnel: true
+  }, [
+    'https connect to localhost:' + s.port,
+    'http response',
+    '200 http ok'
+  ])
+
+  runTest('http over https, tunnel=false, with proxy response', {
+    url: s.url,
+    proxy: ss.url,
+    tunnel: false
+  }, [
+    'https proxy to http',
+    'http response',
+    '200 http ok'
+  ])
+
+  runTest('http over https, tunnel=default, with proxy response', {
+    url: s.url,
+    proxy: ss.url
+  }, [
+    'https proxy to http',
+    'http response',
+    '200 http ok'
+  ])
+
+  // HTTPS OVER HTTP
+
+  runTest('https over http, tunnel=true, with proxy response', {
+    url: ss.url,
+    proxy: s.url,
+    tunnel: true
+  }, [
+    'http connect to localhost:' + ss.port,
+    'https response',
+    '200 https ok'
+  ])
+
+  runTest('https over http, tunnel=false, with proxy response', {
+    url: ss.url,
+    proxy: s.url,
+    tunnel: false
+  }, [
+    'http proxy to https',
+    'https response',
+    '200 https ok'
+  ])
+
+  runTest('https over http, tunnel=default, with proxy response', {
+    url: ss.url,
+    proxy: s.url
+  }, [
+    'http connect to localhost:' + ss.port,
+    'https response',
+    '200 https ok'
+  ])
+
+  // HTTPS OVER HTTPS
+
+  runTest('https over https, tunnel=true, with proxy response', {
+    url: ss.url,
+    proxy: ss.url,
+    tunnel: true
+  }, [
+    'https connect to localhost:' + ss.port,
+    'https response',
+    '200 https ok'
+  ])
+
+  runTest('https over https, tunnel=false, with proxy response', {
+    url: ss.url,
+    proxy: ss.url,
+    tunnel: false,
+    pool: false // must disable pooling here or Node.js hangs
+  }, [
+    'https proxy to https',
+    'https response',
+    '200 https ok'
+  ])
+
+  runTest('https over https, tunnel=default, with proxy response', {
+    url: ss.url,
+    proxy: ss.url
+  }, [
+    'https connect to localhost:' + ss.port,
+    'https response',
+    '200 https ok'
+  ])
+
+  // HTTP->HTTP OVER HTTP
+
+  runTest('http->http over http, tunnel=true, with proxy response', {
+    url: s.url + '/redirect/http',
+    proxy: s.url,
+    tunnel: true
+  }, [
+    'http connect to localhost:' + s.port,
+    'http redirect to http',
+    'http connect to localhost:' + s.port,
+    'http response',
+    '200 http ok'
+  ])
+
+  runTest('http->http over http, tunnel=false, with proxy response', {
+    url: s.url + '/redirect/http',
+    proxy: s.url,
+    tunnel: false
+  }, [
+    'http proxy to http->http',
+    'http redirect to http',
+    'http proxy to http',
+    'http response',
+    '200 http ok'
+  ])
+
+  runTest('http->http over http, tunnel=default, with proxy response', {
+    url: s.url + '/redirect/http',
+    proxy: s.url
+  }, [
+    'http proxy to http->http',
+    'http redirect to http',
+    'http proxy to http',
+    'http response',
+    '200 http ok'
+  ])
+
+  // HTTP->HTTPS OVER HTTP
+
+  runTest('http->https over http, tunnel=true, with proxy response', {
+    url: s.url + '/redirect/https',
+    proxy: s.url,
+    tunnel: true
+  }, [
+    'http connect to localhost:' + s.port,
+    'http redirect to https',
+    'http connect to localhost:' + ss.port,
+    'https response',
+    '200 https ok'
+  ])
+
+  runTest('http->https over http, tunnel=false, with proxy response', {
+    url: s.url + '/redirect/https',
+    proxy: s.url,
+    tunnel: false
+  }, [
+    'http proxy to http->https',
+    'http redirect to https',
+    'http proxy to https',
+    'https response',
+    '200 https ok'
+  ])
+
+  runTest('http->https over http, tunnel=default, with proxy response', {
+    url: s.url + '/redirect/https',
+    proxy: s.url
+  }, [
+    'http proxy to http->https',
+    'http redirect to https',
+    'http connect to localhost:' + ss.port,
+    'https response',
+    '200 https ok'
+  ])
+
+  // HTTPS->HTTP OVER HTTP
+
+  runTest('https->http over http, tunnel=true, with proxy response', {
+    url: ss.url + '/redirect/http',
+    proxy: s.url,
+    tunnel: true
+  }, [
+    'http connect to localhost:' + ss.port,
+    'https redirect to http',
+    'http connect to localhost:' + s.port,
+    'http response',
+    '200 http ok'
+  ])
+
+  runTest('https->http over http, tunnel=false, with proxy response', {
+    url: ss.url + '/redirect/http',
+    proxy: s.url,
+    tunnel: false
+  }, [
+    'http proxy to https->http',
+    'https redirect to http',
+    'http proxy to http',
+    'http response',
+    '200 http ok'
+  ])
+
+  runTest('https->http over http, tunnel=default, with proxy response', {
+    url: ss.url + '/redirect/http',
+    proxy: s.url
+  }, [
+    'http connect to localhost:' + ss.port,
+    'https redirect to http',
+    'http proxy to http',
+    'http response',
+    '200 http ok'
+  ])
+
+  // HTTPS->HTTPS OVER HTTP
+
+  runTest('https->https over http, tunnel=true, with proxy response', {
+    url: ss.url + '/redirect/https',
+    proxy: s.url,
+    tunnel: true
+  }, [
+    'http connect to localhost:' + ss.port,
+    'https redirect to https',
+    'http connect to localhost:' + ss.port,
+    'https response',
+    '200 https ok'
+  ])
+
+  runTest('https->https over http, tunnel=false, with proxy response', {
+    url: ss.url + '/redirect/https',
+    proxy: s.url,
+    tunnel: false
+  }, [
+    'http proxy to https->https',
+    'https redirect to https',
+    'http proxy to https',
+    'https response',
+    '200 https ok'
+  ])
+
+  runTest('https->https over http, tunnel=default, with proxy response', {
+    url: ss.url + '/redirect/https',
+    proxy: s.url
+  }, [
+    'http connect to localhost:' + ss.port,
+    'https redirect to https',
+    'http connect to localhost:' + ss.port,
+    'https response',
+    '200 https ok'
+  ])
+
+  // MUTUAL HTTPS OVER HTTP
+
+  runTest('mutual https over http, tunnel=true, with proxy response', {
+    url: ss2.url,
+    proxy: s.url,
+    tunnel: true,
+    cert: clientCert,
+    key: clientKey,
+    passphrase: clientPassword
+  }, [
+    'http connect to localhost:' + ss2.port,
+    'https response',
+    '200 https ok'
+  ])
+
+  // XXX causes 'Error: socket hang up'
+  // runTest('mutual https over http, tunnel=false, with proxy response', {
+  //   url        : ss2.url,
+  //   proxy      : s.url,
+  //   tunnel     : false,
+  //   cert       : clientCert,
+  //   key        : clientKey,
+  //   passphrase : clientPassword
+  // }, [
+  //   'http connect to localhost:' + ss2.port,
+  //   'https response',
+  //   '200 https ok'
+  // ])
+
+  runTest('mutual https over http, tunnel=default, with proxy response', {
+    url: ss2.url,
+    proxy: s.url,
+    cert: clientCert,
+    key: clientKey,
+    passphrase: clientPassword
+  }, [
+    'http connect to localhost:' + ss2.port,
+    'https response',
+    '200 https ok'
+  ])
+
+  // Client key mismatch for HTTPS over HTTP
+
+  runTest('mutual https over http with client key mismatch, tunnel=default, with proxy response', {
+    url: ss2.url,
+    proxy: s.url,
+    cert: clientCert,
+    key: invalidClientKey
+  }, [
+    'http connect to localhost:' + ss2.port,
+    // it should bubble up the key mismatch error
+    'err error:0B080074:x509 certificate routines:X509_check_private_key:key values mismatch'
+  ])
+}
+
+tape('setup', function (t) {
+  s.listen(0, function () {
+    ss.listen(0, function () {
+      ss2.listen(0, 'localhost', function () {
+        addTests()
+        tape('cleanup', function (t) {
+          s.destroy(function () {
+            ss.destroy(function () {
+              ss2.destroy(function () {
+                t.end()
+              })
+            })
+          })
+        })
+        t.end()
+      })
+    })
+  })
+})

--- a/tests/test-tunnel-response.js
+++ b/tests/test-tunnel-response.js
@@ -36,12 +36,6 @@ var mutualSSLOpts = {
   rejectUnauthorized: true
 }
 
-// this is needed for 'https over http, tunnel=false' test
-// from https://github.com/coolaj86/node-ssl-root-cas/blob/v1.1.9-beta/ssl-root-cas.js#L4267-L4281
-var httpsOpts = https.globalAgent.options
-httpsOpts.ca = httpsOpts.ca || []
-httpsOpts.ca.push(ca)
-
 var s = server.createServer()
 var ss = server.createSSLServer(sslOpts)
 var ss2 = server.createSSLServer(mutualSSLOpts)
@@ -151,16 +145,6 @@ function addTests () {
     '200 http ok'
   ])
 
-  runTest('http over http, tunnel=false, with proxy response', {
-    url: s.url,
-    proxy: s.url,
-    tunnel: false
-  }, [
-    'http proxy to http',
-    'http response',
-    '200 http ok'
-  ])
-
   runTest('http over http, tunnel=default, with proxy response', {
     url: s.url,
     proxy: s.url
@@ -178,16 +162,6 @@ function addTests () {
     tunnel: true
   }, [
     'https connect to localhost:' + s.port,
-    'http response',
-    '200 http ok'
-  ])
-
-  runTest('http over https, tunnel=false, with proxy response', {
-    url: s.url,
-    proxy: ss.url,
-    tunnel: false
-  }, [
-    'https proxy to http',
     'http response',
     '200 http ok'
   ])
@@ -213,16 +187,6 @@ function addTests () {
     '200 https ok'
   ])
 
-  runTest('https over http, tunnel=false, with proxy response', {
-    url: ss.url,
-    proxy: s.url,
-    tunnel: false
-  }, [
-    'http proxy to https',
-    'https response',
-    '200 https ok'
-  ])
-
   runTest('https over http, tunnel=default, with proxy response', {
     url: ss.url,
     proxy: s.url
@@ -240,17 +204,6 @@ function addTests () {
     tunnel: true
   }, [
     'https connect to localhost:' + ss.port,
-    'https response',
-    '200 https ok'
-  ])
-
-  runTest('https over https, tunnel=false, with proxy response', {
-    url: ss.url,
-    proxy: ss.url,
-    tunnel: false,
-    pool: false // must disable pooling here or Node.js hangs
-  }, [
-    'https proxy to https',
     'https response',
     '200 https ok'
   ])
@@ -274,18 +227,6 @@ function addTests () {
     'http connect to localhost:' + s.port,
     'http redirect to http',
     'http connect to localhost:' + s.port,
-    'http response',
-    '200 http ok'
-  ])
-
-  runTest('http->http over http, tunnel=false, with proxy response', {
-    url: s.url + '/redirect/http',
-    proxy: s.url,
-    tunnel: false
-  }, [
-    'http proxy to http->http',
-    'http redirect to http',
-    'http proxy to http',
     'http response',
     '200 http ok'
   ])
@@ -315,18 +256,6 @@ function addTests () {
     '200 https ok'
   ])
 
-  runTest('http->https over http, tunnel=false, with proxy response', {
-    url: s.url + '/redirect/https',
-    proxy: s.url,
-    tunnel: false
-  }, [
-    'http proxy to http->https',
-    'http redirect to https',
-    'http proxy to https',
-    'https response',
-    '200 https ok'
-  ])
-
   runTest('http->https over http, tunnel=default, with proxy response', {
     url: s.url + '/redirect/https',
     proxy: s.url
@@ -348,18 +277,6 @@ function addTests () {
     'http connect to localhost:' + ss.port,
     'https redirect to http',
     'http connect to localhost:' + s.port,
-    'http response',
-    '200 http ok'
-  ])
-
-  runTest('https->http over http, tunnel=false, with proxy response', {
-    url: ss.url + '/redirect/http',
-    proxy: s.url,
-    tunnel: false
-  }, [
-    'http proxy to https->http',
-    'https redirect to http',
-    'http proxy to http',
     'http response',
     '200 http ok'
   ])
@@ -389,18 +306,6 @@ function addTests () {
     '200 https ok'
   ])
 
-  runTest('https->https over http, tunnel=false, with proxy response', {
-    url: ss.url + '/redirect/https',
-    proxy: s.url,
-    tunnel: false
-  }, [
-    'http proxy to https->https',
-    'https redirect to https',
-    'http proxy to https',
-    'https response',
-    '200 https ok'
-  ])
-
   runTest('https->https over http, tunnel=default, with proxy response', {
     url: ss.url + '/redirect/https',
     proxy: s.url
@@ -426,20 +331,6 @@ function addTests () {
     'https response',
     '200 https ok'
   ])
-
-  // XXX causes 'Error: socket hang up'
-  // runTest('mutual https over http, tunnel=false, with proxy response', {
-  //   url        : ss2.url,
-  //   proxy      : s.url,
-  //   tunnel     : false,
-  //   cert       : clientCert,
-  //   key        : clientKey,
-  //   passphrase : clientPassword
-  // }, [
-  //   'http connect to localhost:' + ss2.port,
-  //   'https response',
-  //   '200 https ok'
-  // ])
 
   runTest('mutual https over http, tunnel=default, with proxy response', {
     url: ss2.url,


### PR DESCRIPTION
## PR Checklist:
- [x] I have run `npm test` locally and all tests are passing.
- [x] I have added/updated tests for any new behavior.
- [x] If this is a significant change, an issue has already been created where the problem / solution was discussed: n/a


## PR Description

This change updates the tunnel-agent such that it does not throw
assertion error when proxy server sends a response to the CONNECT
request. This also adds tests for this case.