### PR TITLE
Change 'proxy' option to support object with URL and Auth

### DIFF
--- a/lib/tunnel.js
+++ b/lib/tunnel.js
@@ -139,6 +139,24 @@ Tunnel.prototype.setup = function (options) {
   if (typeof request.proxy === 'string') {
     request.proxy = url.parse(request.proxy)
   }
+  else if (
+    request.proxy &&
+    typeof request.proxy === 'object' &&
+
+    // to avoid processing proxy object multiple times on redirects
+    !(request.proxy instanceof url.Url)
+  ) {
+    var proxyUrl = request.proxy.url
+    var auth = request.proxy.auth
+
+    request.proxy = typeof proxyUrl === 'string' ? url.parse(proxyUrl) : proxyUrl
+
+    if (auth) {
+      request.proxy.auth = auth.username || ''
+
+      auth.password && (request.proxy.auth += ':' + auth.password);
+    }
+  }
 
   if (!request.proxy || !request.tunnel) {
     return false


### PR DESCRIPTION
Now 'proxy' option also supports object with below structure:

```javascript
proxy: {
    url: <String/NodeURL>,
    auth: 'basic',
    baasic: {
        username: String,
        password: String
    }
}
```

Todo:
- [ ] Update tunnel-agent
- [ ] Add/Update tests