### PR TITLE
Added basic support for brotli decoding of responses

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "request.js"
   ],
   "dependencies": {
+    "@postman/tunnel-agent": "^0.6.3",
     "aws-sign2": "~0.7.0",
     "aws4": "^1.8.0",
     "caseless": "~0.12.0",
@@ -32,6 +33,7 @@
     "form-data": "~2.3.2",
     "har-validator": "~5.1.3",
     "http-signature": "~1.2.0",
+    "iltorb": "^2.4.4",
     "is-typedarray": "~1.0.0",
     "isstream": "~0.1.2",
     "json-stringify-safe": "~5.0.1",
@@ -43,7 +45,6 @@
     "safe-buffer": "^5.1.2",
     "stream-length": "^1.0.2",
     "tough-cookie": "~2.5.0",
-    "@postman/tunnel-agent": "^0.6.3",
     "uuid": "^3.3.2"
   },
   "scripts": {


### PR DESCRIPTION
## PR Checklist:
- [x] I have run `npm test` locally and all tests are passing.
- [x] A test is not required for this
       <!-- Request is a complex project, there are VERY FEW exceptions
               where a new test is not required for new behavior. -->
- [x] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]
       <!-- If you'd like to suggest a significant change to request,
               please create an issue to discuss those changes and gather
               feedback BEFORE submitting your PR. -->


## PR Description
Ported to safer `Buffer.from` of NodeJS with backward compatibility where the same is not available. This issue is only in one location where response `deflate` is being done.
