### PR TITLE
Added `allowContentTypeOverride` option

### DIFF
--- a/request.js
+++ b/request.js
@@ -1560,8 +1560,9 @@ Request.prototype.qs = function (q, clobber) {
 Request.prototype.form = function (form) {
   var self = this
   var contentType = self.getHeader('content-type')
+  var overrideInvalidContentType = contentType ? !self.allowContentTypeOverride : true
   if (form) {
-    if (!/^application\/x-www-form-urlencoded\b/.test(contentType)) {
+    if (overrideInvalidContentType && !/^application\/x-www-form-urlencoded\b/.test(contentType)) {
       self.setHeader('Content-Type', 'application/x-www-form-urlencoded')
     }
     self.body = (typeof form === 'string')
@@ -1581,7 +1582,7 @@ Request.prototype.form = function (form) {
     self.emit('error', err)
     self.abort()
   })
-  if (!contentTypeMatch) {
+  if (overrideInvalidContentType && !contentTypeMatch) {
     // overrides invalid or missing content-type
     self.setHeader('Content-Type', 'multipart/form-data; boundary=' + self._form.getBoundary())
   }

--- a/tests/test-form-data-boundary.js
+++ b/tests/test-form-data-boundary.js
@@ -226,6 +226,85 @@ tape('custom boundary with multipart/mixed', function (t) {
   })
 })
 
+tape('invalid content-type', function (t) {
+  request.post({
+    url: server.url,
+    headers: {
+      'content-type': 'something/else'
+    },
+    formData: {
+      formKey: 'formValue'
+    }
+  }, function (err, res, body) {
+    var req = JSON.parse(body)
+    var boundary
+    t.equal(err, null)
+    t.equal(res.statusCode, 200)
+
+    // overridden content-type
+    t.ok(/multipart\/form-data; boundary=--------------------------\d+/
+      .test(req.headers['content-type']))
+
+    boundary = req.headers['content-type'].split('boundary=')[1]
+    t.ok(/--------------------------\d+/.test(boundary))
+    t.ok(req.body.startsWith('--' + boundary))
+    t.ok(req.body.indexOf('name="formKey"') !== -1)
+    t.ok(req.body.indexOf('formValue') !== -1)
+    t.ok(req.body.endsWith(boundary + '--\r\n'))
+    t.end()
+  })
+})
+
+tape('invalid content-type with allowContentTypeOverride', function (t) {
+  request.post({
+    url: server.url,
+    headers: {
+      'content-type': 'something/else'
+    },
+    formData: {
+      formKey: 'formValue'
+    },
+    allowContentTypeOverride: true
+  }, function (err, res, body) {
+    var req = JSON.parse(body)
+    t.equal(err, null)
+    t.equal(res.statusCode, 200)
+    t.equal(req.headers['content-type'], 'something/else')
+    t.ok(req.body.startsWith('--'))
+    t.ok(req.body.indexOf('name="formKey"') !== -1)
+    t.ok(req.body.indexOf('formValue') !== -1)
+    t.ok(req.body.endsWith('--\r\n'))
+    t.end()
+  })
+})
+
+tape('allowContentTypeOverride with no content-type', function (t) {
+  request.post({
+    url: server.url,
+    formData: {
+      formKey: 'formValue'
+    },
+    allowContentTypeOverride: true
+  }, function (err, res, body) {
+    var req = JSON.parse(body)
+    var boundary
+    t.equal(err, null)
+    t.equal(res.statusCode, 200)
+
+    // overridden content-type
+    t.ok(/multipart\/form-data; boundary=--------------------------\d+/
+      .test(req.headers['content-type']))
+
+    boundary = req.headers['content-type'].split('boundary=')[1]
+    t.ok(/--------------------------\d+/.test(boundary))
+    t.ok(req.body.startsWith('--' + boundary))
+    t.ok(req.body.indexOf('name="formKey"') !== -1)
+    t.ok(req.body.indexOf('formValue') !== -1)
+    t.ok(req.body.endsWith(boundary + '--\r\n'))
+    t.end()
+  })
+})
+
 tape('cleanup', function (t) {
   server.destroy(function () {
     t.end()


### PR DESCRIPTION
## PR Checklist:
- [x] I have run `npm test` locally and all tests are passing.
- [x] I have added/updated tests for any new behavior.
       <!-- Request is a complex project, there are VERY FEW exceptions
               where a new test is not required for new behavior. -->
- [x] If this is a significant change, an issue has already been created where the problem / solution was discussed: https://github.com/postmanlabs/postman-app-support/issues/7878
       <!-- If you'd like to suggest a significant change to request,
               please create an issue to discuss those changes and gather
               feedback BEFORE submitting your PR. -->


## PR Description
Added an option `allowContentTypeOverride` to allow overriding invalid content-type header for form-data and url-encoded request bodies.
