### PR TITLE
Add fallback for mime.lookup

### DIFF
--- a/request.js
+++ b/request.js
@@ -587,7 +587,8 @@ Request.prototype.init = function (options) {
     self.src = src
     if (isReadStream(src)) {
       if (!self.hasHeader('content-type')) {
-        self.setHeader('Content-Type', mime.lookup(src.path))
+        // @note fallback to 'application/octet-stream' if mime.lookup returns `false`
+        self.setHeader('Content-Type', mime.lookup(src.path) || 'application/octet-stream')
       }
     } else {
       if (src.headers) {
@@ -897,6 +898,8 @@ Request.prototype.start = function () {
     if (Array.isArray(self.blacklistHeaders) && self.blacklistHeaders.length) {
       self.blacklistHeaders.forEach(function (header) {
         self.req.removeHeader(header)
+        // also remove from the `self` for the consistency
+        self.removeHeader(header)
       })
     }
   } catch (err) {

--- a/tests/raw.file
+++ b/tests/raw.file
@@ -1,0 +1,1 @@
+Hello World!

--- a/tests/test-body.js
+++ b/tests/test-body.js
@@ -4,6 +4,8 @@ var server = require('./server')
 var request = require('../index')
 var tape = require('tape')
 var http = require('http')
+var path = require('path')
+var fs = require('fs')
 
 var s = server.createServer()
 
@@ -125,6 +127,25 @@ addTest('testPutMultipartPostambleCRLF', {
   multipart: [ {'content-type': 'text/html', 'body': '<html><body>Oh hi.</body></html>'},
     {'body': 'Oh hi.'}
   ]
+})
+
+tape('testBinaryFile', function (t) {
+  var server = http.createServer()
+  server.on('request', function (req, res) {
+    req.pipe(res)
+  })
+  server.listen(0, function () {
+    request({
+      uri: 'http://localhost:' + this.address().port,
+      method: 'POST',
+      body: fs.createReadStream(path.join(__dirname, 'raw.file'))
+    }, function (err, res, body) {
+      t.error(err)
+      // defaults to 'application/octet-stream' content-type
+      t.equal(res.request.headers['Content-Type'], 'application/octet-stream')
+      server.close(t.end)
+    })
+  })
 })
 
 tape('typed array', function (t) {


### PR DESCRIPTION
## PR Checklist:
- [x] I have run `npm test` locally and all tests are passing.
- [x] I have added/updated tests for any new behavior.
       <!-- Request is a complex project, there are VERY FEW exceptions
               where a new test is not required for new behavior. -->
- [ ] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]
       <!-- If you'd like to suggest a significant change to request,
               please create an issue to discuss those changes and gather
               feedback BEFORE submitting your PR. -->


## PR Description
Instead of returning the first available type, [mime-types](https://github.com/jshttp/mime-types) simply returns `false`, so fallback to `application/octet-stream`.