### PR TITLE
Add default `Content-Length` header

### DIFF
--- a/request.js
+++ b/request.js
@@ -658,12 +658,23 @@ Request.prototype.init = function (options) {
         console.warn('options.requestBodyStream is deprecated, please pass the request object to stream.pipe.')
         self.requestBodyStream.pipe(self)
       } else if (!self.src) {
-        if (self._auth.hasAuth && !self._auth.sentAuth) {
+        if ((self._auth.hasAuth && !self._auth.sentAuth) || self.hasHeader('content-length')) {
           self.end()
           return
         }
-        if (self.method !== 'GET' && typeof self.method !== 'undefined') {
-          self.setHeader('Content-Length', 0)
+        switch (self.method) {
+          case 'GET':
+          case 'HEAD':
+          case 'TRACE':
+          case 'DELETE':
+          case 'CONNECT':
+          case 'OPTIONS':
+          case undefined:
+            // @note this behavior is same as Node.js
+            break
+          default:
+            self.setHeader('Content-Length', 0)
+            break
         }
         self.end()
       }

--- a/tests/test-default-headers.js
+++ b/tests/test-default-headers.js
@@ -1,0 +1,73 @@
+'use strict'
+
+var METHODS = require('http').METHODS
+var tape = require('tape')
+var destroyable = require('server-destroy')
+
+var request = require('../index')
+var httpServer = require('./server').createServer()
+
+destroyable(httpServer)
+
+function forEachAsync (items, fn, cb) {
+  !cb && (cb = function () { /* (ಠ_ಠ) */ })
+
+  if (!(Array.isArray(items) && fn)) { return cb() }
+
+  var index = 0
+  var totalItems = items.length
+  function next (err) {
+    if (err || index >= totalItems) {
+      return cb(err)
+    }
+
+    try {
+      fn.call(items, items[index++], next)
+    } catch (error) {
+      return cb(error)
+    }
+  }
+
+  if (!totalItems) { return cb() }
+
+  next()
+}
+
+tape('setup', function (t) {
+  httpServer.listen(0, t.end)
+})
+
+tape('default headers', function (t) {
+  var url = httpServer.url
+  // @note Node.js <= v10 force adds content-length
+  var traceHeaders = parseInt(process.version.slice(1)) <= 10
+    ? 'host | connection | content-length' : 'host | connection'
+
+  httpServer.on('request', function (req, res) {
+    var headers = Object.keys(req.headers).join(' | ')
+    switch (req.method) {
+      case 'GET':
+      case 'HEAD':
+      case 'DELETE':
+      case 'OPTIONS':
+        t.equal(headers, 'host | connection')
+        break
+      case 'TRACE':
+        t.equal(headers, traceHeaders)
+        break
+      default:
+        t.equal(headers, 'host | content-length | connection')
+        break
+    }
+    res.end()
+  })
+
+  forEachAsync(METHODS, function (method, next) {
+    if (method === 'CONNECT') { return next() }
+    request({ url, method }, next)
+  }, t.end)
+})
+
+tape('cleanup', function (t) {
+  httpServer.destroy(t.end)
+})


### PR DESCRIPTION
## PR Checklist:
- [x] I have run `npm test` locally and all tests are passing.
- [x] I have added/updated tests for any new behavior.
       <!-- Request is a complex project, there are VERY FEW exceptions
               where a new test is not required for new behavior. -->
- [x] If this is a significant change, an issue has already been created where the problem / solution was discussed: N/A
       <!-- If you'd like to suggest a significant change to request,
               please create an issue to discuss those changes and gather
               feedback BEFORE submitting your PR. -->


## PR Description
Add default `Content-Length` header (same as Node.js) for the following methods:
- GET
- HEAD
- TRACE
- DELETE
- CONNECT
- OPTIONS

It also fixes a bug where custom `Content-Length` was not honored for the empty body.