### PR TITLE
Added support for specifying separate agents for HTTP and HTTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -949,6 +949,18 @@ The first argument can be either a `url` or an `options` object. The only requir
 - `agent` - `http(s).Agent` instance to use
 - `agentClass` - alternatively specify your agent's class name
 - `agentOptions` - and pass its options. **Note:** for HTTPS see [tls API doc for TLS/SSL options](http://nodejs.org/api/tls.html#tls_tls_connect_options_callback) and the [documentation above](#using-optionsagentoptions).
+- `agents` - Specify separate agent instances for HTTP and HTTPS requests. Required in case of HTTP to HTTPS redirects and vice versa. For example:
+```js
+request.defaults({
+  agents: {
+    http: new http.Agent(),
+    https: {
+      agentClass: https.Agent,
+      agentOptions: { keepAlive: true }
+    }
+  }
+})
+```
 - `forever` - set to `true` to use the [forever-agent](https://github.com/request/forever-agent) **Note:** Defaults to `http(s).Agent({keepAlive:true})` in node 0.12+
 - `pool` - an object describing which agents to use for the request. If this option is omitted the request will use the global agent (as long as your options allow for it). Otherwise, request will search the pool for your custom agent. If no custom agent is found, a new agent will be created and added to the pool. **Note:** `pool` is used only when the `agent` option is not specified.
   - A `maxSockets` property can also be provided on the `pool` object to set the max number of sockets for all agents created (ex: `pool: {maxSockets: Infinity}`).
@@ -1086,7 +1098,7 @@ Function that returns the specified response header field using a [case-insensit
 ```js
 request('http://www.google.com', function (error, response, body) {
   // print the Content-Type header even if the server returned it as 'content-type' (lowercase)
-  console.log('Content-Type is:', response.caseless.get('Content-Type')); 
+  console.log('Content-Type is:', response.caseless.get('Content-Type'));
 });
 ```
 

--- a/request.js
+++ b/request.js
@@ -552,6 +552,19 @@ Request.prototype.init = function (options) {
     self.ca = options.ca
   }
 
+  // prefer common self.agent if exists
+  if (self.agents && !self.agent) {
+    var agent = protocol === 'http:' ? self.agents.http : self.agents.https
+    if (agent) {
+      if (agent.agentClass || agent.agentOptions) {
+        options.agentClass = agent.agentClass || options.agentClass
+        options.agentOptions = agent.agentOptions || options.agentOptions
+      } else {
+        self.agent = agent
+      }
+    }
+  }
+
   if (!self.agent) {
     if (options.agentOptions) {
       self.agentOptions = options.agentOptions

--- a/tests/test-agents.js
+++ b/tests/test-agents.js
@@ -1,0 +1,111 @@
+'use strict'
+
+var request = require('../index')
+var http = require('http')
+var https = require('https')
+var tape = require('tape')
+
+tape('http', function (t) {
+  var r = request({
+    uri: 'http://httpbin.org/get',
+    agents: {
+      http: new http.Agent({option1: true})
+    }
+  }, function (err, res) {
+    t.equal(err, null)
+    t.equal(res.statusCode, 200)
+    t.ok(r.agent instanceof http.Agent, 'is http.Agent')
+    t.equal(r.agent.options.option1, true)
+    t.end()
+  })
+})
+
+tape('http.agentClass + http.agentOptions', function (t) {
+  var r = request({
+    uri: 'http://httpbin.org/get',
+    agents: {
+      http: {
+        agentClass: http.Agent,
+        agentOptions: {option2: true}
+      }
+    }
+  }, function (err, res) {
+    t.equal(err, null)
+    t.equal(res.statusCode, 200)
+    t.ok(r.agent instanceof http.Agent, 'is http.Agent')
+    t.equal(r.agent.options.option2, true)
+    t.equal(Object.keys(r.agent.sockets).length, 1, '1 socket name')
+    t.end()
+  })
+})
+
+tape('https', function (t) {
+  var r = request({
+    uri: 'https://httpbin.org/get',
+    agents: {
+      https: new https.Agent({option3: true})
+    }
+  }, function (err, res) {
+    t.equal(err, null)
+    t.equal(res.statusCode, 200)
+    t.ok(r.agent instanceof https.Agent, 'is https.Agent')
+    t.equal(r.agent.protocol, 'https:', 'is https.Agent for sure')
+    t.equal(r.agent.options.option3, true)
+    t.equal(Object.keys(r.agent.sockets).length, 1, '1 socket name')
+    t.end()
+  })
+})
+
+tape('https.agentClass + https.agentOptions', function (t) {
+  var r = request({
+    uri: 'https://httpbin.org/get',
+    agents: {
+      https: {
+        agentClass: https.Agent,
+        agentOptions: {option4: true}
+      }
+    }
+  }, function (err, res) {
+    t.equal(err, null)
+    t.equal(res.statusCode, 200)
+    t.ok(r.agent instanceof https.Agent, 'is https.Agent')
+    t.equal(r.agent.protocol, 'https:', 'is https.Agent for sure')
+    t.equal(r.agent.options.option4, true)
+    t.equal(Object.keys(r.agent.sockets).length, 1, '1 socket name')
+    t.end()
+  })
+})
+
+tape('http & https', function (t) {
+  var r = request({
+    uri: 'http://postman-echo.com/redirect-to?url=https://httpbin.org/get',
+    agents: {
+      http: new http.Agent({option5: true}),
+      https: new https.Agent({option6: true})
+    }
+  }, function (err, res) {
+    t.equal(err, null)
+    t.equal(res.statusCode, 200)
+    t.ok(r.agent instanceof https.Agent, 'is https.Agent')
+    t.equal(r.agent.protocol, 'https:', 'is https.Agent for sure')
+    t.equal(r.agent.options.option6, true)
+    t.equal(Object.keys(r.agent.sockets).length, 1, '1 socket name')
+    t.end()
+  })
+})
+
+tape('https & http', function (t) {
+  var r = request({
+    uri: 'https://httpbin.org/redirect-to?url=http://postman-echo.com/get',
+    agents: {
+      http: new http.Agent({option7: true}),
+      https: new https.Agent({option8: true})
+    }
+  }, function (err, res, body) {
+    t.equal(err, null)
+    t.equal(res.statusCode, 200)
+    t.ok(r.agent instanceof http.Agent, 'is http.Agent')
+    t.equal(r.agent.options.option7, true)
+    t.end()
+  })
+})


### PR DESCRIPTION
## PR Checklist:
- [x] I have run `npm test` locally and all tests are passing.
- [x] I have added/updated tests for any new behavior.
       <!-- Request is a complex project, there are VERY FEW exceptions
               where a new test is not required for new behavior. -->
- [x] If this is a significant change, an issue has already been created where the problem / solution was discussed: https://github.com/postmanlabs/newman/pull/2349#issuecomment-634357856
       <!-- If you'd like to suggest a significant change to request,
               please create an issue to discuss those changes and gather
               feedback BEFORE submitting your PR. -->

## PR Description
Added new `agents` options which accept separate agent instance for `http` and `https`.
