### PR TITLE
Allow :// to occur in the path even when baseUrl is used, as long as it's not at the beginning.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ coverage
 .idea
 npm-debug.log
 package-lock.json
+.nyc_output

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## Change Log
 
+### v2.88.0 (2018/08/10)
+- [#2996](https://github.com/request/request/pull/2996) fix(uuid): import versioned uuid (@kwonoj)
+- [#2994](https://github.com/request/request/pull/2994) Update to oauth-sign 0.9.0 (@dlecocq)
+- [#2993](https://github.com/request/request/pull/2993) Fix header tests (@simov)
+- [#2904](https://github.com/request/request/pull/2904) #515, #2894 Strip port suffix from Host header if the protocol is known. (#2904) (@paambaati)
+- [#2791](https://github.com/request/request/pull/2791) Improve AWS SigV4 support. (#2791) (@vikhyat)
+- [#2977](https://github.com/request/request/pull/2977) Update test certificates (@simov)
+
 ### v2.87.0 (2018/05/21)
 - [#2943](https://github.com/request/request/pull/2943) Replace hawk dependency with a local implemenation (#2943) (@hueniverse)
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Request is designed to be the simplest way possible to make http calls. It suppo
 ```js
 const request = require('request');
 request('http://www.google.com', function (error, response, body) {
-  console.log('error:', error); // Print the error if one occurred
+  console.error('error:', error); // Print the error if one occurred
   console.log('statusCode:', response && response.statusCode); // Print the response status code if a response was received
   console.log('body:', body); // Print the HTML for the Google homepage.
 });
@@ -86,7 +86,7 @@ To easily handle errors when streaming requests, listen to the `error` event bef
 request
   .get('http://mysite.com/doodle.png')
   .on('error', function(err) {
-    console.log(err)
+    console.error(err)
   })
   .pipe(fs.createWriteStream('doodle.png'))
 ```

--- a/README.md
+++ b/README.md
@@ -823,12 +823,9 @@ The first argument can be either a `url` or an `options` object. The only requir
     work around this, either use [`request.defaults`](#requestdefaultsoptions)
     with your pool options or create the pool object with the `maxSockets`
     property outside of the loop.
-- `timeout` - integer containing number of milliseconds, controls two timeouts
-  - Time to wait for a server to send response headers (and start the response body) before aborting the request.
-    Note that if the underlying TCP connection cannot be established,
-    the OS-wide TCP connection timeout will overrule the `timeout` option ([the
-    default in Linux can be anywhere from 20-120 seconds][linux-timeout]).
-  - Sets the socket to timeout after `timeout` milliseconds of inactivity on the socket.
+- `timeout` - integer containing number of milliseconds, controls two timeouts.
+  - **Read timeout**: Time to wait for a server to send response headers (and start the response body) before aborting the request.
+  - **Connection timeout**: Sets the socket to timeout after `timeout` milliseconds of inactivity. Note that increasing the timeout beyond the OS-wide TCP connection timeout will not have any effect ([the default in Linux can be anywhere from 20-120 seconds][linux-timeout])
 
 [linux-timeout]: http://www.sekuda.com/overriding_the_default_linux_kernel_20_second_tcp_socket_connect_timeout
 

--- a/lib/getProxyFromURI.js
+++ b/lib/getProxyFromURI.js
@@ -40,7 +40,7 @@ function uriInNoProxy (uri, noProxy) {
 function getProxyFromURI (uri) {
   // Decide the proper request proxy to use based on the request URI object and the
   // environmental variables (NO_PROXY, HTTP_PROXY, etc.)
-  // respect NO_PROXY environment variables (see: http://lynx.isc.org/current/breakout/lynx_help/keystrokes/environments.html)
+  // respect NO_PROXY environment variables (see: https://lynx.invisible-island.net/lynx2.8.7/breakout/lynx_help/keystrokes/environments.html)
 
   var noProxy = process.env.NO_PROXY || process.env.no_proxy || ''
 

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   "scripts": {
     "test": "npm run lint && npm run test-ci && npm run test-browser",
     "test-ci": "taper tests/test-*.js",
-    "test-cov": "istanbul cover tape tests/test-*.js",
+    "test-cov": "nyc --reporter=lcov tape tests/test-*.js",
     "test-browser": "node tests/browser/start.js",
     "lint": "standard"
   },
@@ -63,13 +63,13 @@
     "codecov": "^3.0.4",
     "coveralls": "^3.0.2",
     "function-bind": "^1.0.2",
-    "istanbul": "^0.4.0",
     "karma": "^3.0.0",
     "karma-browserify": "^5.0.1",
     "karma-cli": "^1.0.0",
     "karma-coverage": "^1.0.0",
     "karma-phantomjs-launcher": "^1.0.0",
     "karma-tap": "^3.0.1",
+    "nyc": "^14.1.1",
     "phantomjs-prebuilt": "^2.1.3",
     "rimraf": "^2.2.8",
     "server-destroy": "^1.0.1",

--- a/request.js
+++ b/request.js
@@ -205,7 +205,7 @@ Request.prototype.init = function (options) {
       return self.emit('error', new Error('options.uri must be a string when using options.baseUrl'))
     }
 
-    if (self.uri.indexOf('//') === 0 || self.uri.indexOf('://') !== -1) {
+    if (self.uri.indexOf('//') === 0 || self.uri.match(/^\w+:\/\//)) {
       return self.emit('error', new Error('options.uri must be a path when using options.baseUrl'))
     }
 

--- a/tests/test-baseUrl.js
+++ b/tests/test-baseUrl.js
@@ -131,3 +131,12 @@ tape('error on baseUrl and uri with scheme-relative url', function (t) {
     t.end()
   })
 })
+
+tape('no error when scheme occurs later in path', function (t) {
+  request('/login?next=http://yourhome.com', {
+    baseUrl: s.url + '/path/'
+  }, function (err, resp, body) {
+    t.equal(err, null)
+    t.end()
+  })
+})


### PR DESCRIPTION
## PR Checklist:
- [x] I have run `npm test` locally and all tests are passing.
- [x] I have added/updated tests for any new behavior.
       <!-- Request is a complex project, there are VERY FEW exceptions
               where a new test is not required for new behavior. -->
- [x] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]
       <!-- If you'd like to suggest a significant change to request,
               please create an issue to discuss those changes and gather
               feedback BEFORE submitting your PR. -->

## PR Description
Fixes https://github.com/request/request/issues/2857

Howdy, this is a one-liner fix I was trying for years to get any owners of request/request to look at. That original PR is here:

https://github.com/request/request/pull/2888

When using a base URL it won't allow `https://` to occur in the path, but of course that's perfectly valid as long as it's not at the start, like in the query string for example.

Want to merge it in? Github doesn't want to let me make a fork of your fork, when I already had a fork of request/request, so I think you'd have to copy and paste this in.
