### PR TITLE
Fix debug info object to return string as per documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -778,8 +778,8 @@ request({url: 'https://www.google.com', verbose: true}, function (error, respons
                 "organization": "Google Trust Services",
                 "commonName": "Google Internet Authority G3"
               },
-              "validFrom": "2019-03-01T09:46:35.000Z",
-              "validTo": "2019-05-24T09:25:00.000Z",
+              "validFrom": "Nov 11 09:52:22 2009 GMT",
+              "validTo": "Nov 6 09:52:22 2029 GMT",
               "fingerprint": "DF:6B:95:81:C6:03:EB:ED:48:EB:6C:CF:EE:FE:E6:1F:AD:01:78:34",
               "serialNumber": "3A15F4C87FB4D33993D3EEB3BF4AE5E4"
             }

--- a/request.js
+++ b/request.js
@@ -1056,8 +1056,8 @@ Request.prototype.start = function () {
                 organizationalUnit: peerCert.issuer.OU,
                 commonName: peerCert.issuer.CN
               },
-              validFrom: peerCert.valid_from && new Date(peerCert.valid_from),
-              validTo: peerCert.valid_to && new Date(peerCert.valid_to),
+              validFrom: peerCert.valid_from,
+              validTo: peerCert.valid_to,
               fingerprint: peerCert.fingerprint,
               serialNumber: peerCert.serialNumber
             }


### PR DESCRIPTION
## PR Checklist:
- [x] I have run `npm test` locally and all tests are passing.
- [x] I have added/updated tests for any new behavior.
       <!-- Request is a complex project, there are VERY FEW exceptions
               where a new test is not required for new behavior. -->
- [x] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]
       <!-- If you'd like to suggest a significant change to request,
               please create an issue to discuss those changes and gather
               feedback BEFORE submitting your PR. -->


## PR Description
- In both Runtime and Postman documentation, type of `validFrom` and `validTo` properties in `debug.session.tls.peerCertificate` object is documented as String. But it was actually returning the Date object instead.
- Fixed the return type of the said properties to match the documentation 
