### PR TITLE
Fixed encoding of auth component in the proxy url

### DIFF
--- a/request.js
+++ b/request.js
@@ -360,6 +360,14 @@ Request.prototype.init = function (options) {
     self.proxy = getProxyFromURI(self.uri)
   }
 
+  if (typeof self.proxy === 'string') {
+    self.proxy = self.urlParser.parse(self.proxy)
+
+    if (self.proxy.auth) {
+      self.proxy.auth = self._qs.unescape(self.proxy.auth)
+    }
+  }
+
   self.tunnel = self._tunnel.isEnabled()
   if (self.proxy) {
     self._tunnel.setup(options)
@@ -473,9 +481,7 @@ Request.prototype.init = function (options) {
   }
 
   if (!self.tunnel && self.proxy && self.proxy.auth && !self.hasHeader('proxy-authorization')) {
-    var proxyAuthPieces = self.proxy.auth.split(':').map(function (item) { return self._qs.unescape(item) })
-    var authHeader = 'Basic ' + toBase64(proxyAuthPieces.join(':'))
-    self.setHeader('Proxy-Authorization', authHeader)
+    self.setHeader('Proxy-Authorization', 'Basic ' + toBase64(self.proxy.auth))
   }
 
   if (self.proxy && !self.tunnel) {


### PR DESCRIPTION
## PR Checklist:
- [x] I have run `npm test` locally and all tests are passing.
- [x] I have added/updated tests for any new behavior.
       <!-- Request is a complex project, there are VERY FEW exceptions
               where a new test is not required for new behavior. -->
- [ ] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]
       <!-- If you'd like to suggest a significant change to request,
               please create an issue to discuss those changes and gather
               feedback BEFORE submitting your PR. -->


## PR Description
Fixed a bug where proxy URL was parsed at multiple places without unescaping the auth component.