### PR TITLE
Change structure of headers in debug object

### DIFF
--- a/request.js
+++ b/request.js
@@ -894,7 +894,7 @@ Request.prototype.start = function () {
   self._reqResInfo.request = {
     method: self.method,
     href: self.uri.href,
-    headers: this.headers,
+    headers: Object.assign({}, self.headers),
     proxy: (self.proxy && { href: self.proxy.href }) || undefined,
     httpVersion: '1.1'
   }

--- a/request.js
+++ b/request.js
@@ -127,6 +127,16 @@ function responseToJSON () {
   }
 }
 
+// Return headers in {key: value} form
+function headersStringToObject (headerString) {
+  var arr = headerString.split('\r\n'), acc = {}, splitIndex, i;
+  for(i = 1; i < arr.length - 2; i++) {
+    splitIndex = arr[i].indexOf(':');
+    acc[arr[i].slice(0, splitIndex)] = arr[i].slice(splitIndex + 2);
+  }
+  return acc;
+}
+
 function Request (options) {
   // if given the method property in options, set property explicitMethod to true
 
@@ -894,7 +904,6 @@ Request.prototype.start = function () {
   self._reqResInfo.request = {
     method: self.method,
     href: self.uri.href,
-    headers: Object.assign({}, self.headers),
     proxy: (self.proxy && { href: self.proxy.href }) || undefined,
     httpVersion: '1.1'
   }
@@ -1900,6 +1909,7 @@ Request.prototype.end = function (chunk) {
   if (self.req) {
     self.req.end()
   }
+  self._reqResInfo.request.headers = headersStringToObject(self.req._header);
 }
 Request.prototype.pause = function () {
   var self = this

--- a/request.js
+++ b/request.js
@@ -145,7 +145,7 @@ function parseRequestHeaders (headerString) {
   return acc
 }
 
-// Return request headers in {key: value} form
+// Return response headers in {key: value} form
 function parseResponseHeaders (rawHeaders) {
   var acc = []
   for (var i = 0; i < rawHeaders.length; i = i + 2) {

--- a/request.js
+++ b/request.js
@@ -129,6 +129,9 @@ function responseToJSON () {
 
 // Return request headers in {key: value} form
 function parseRequestHeaders (headerString) {
+  if (!headerString) {
+    return
+  }
   var arr = headerString.split('\r\n')
   var acc = []
   for (var i = 1; i < arr.length - 2; i++) {

--- a/request.js
+++ b/request.js
@@ -127,14 +127,30 @@ function responseToJSON () {
   }
 }
 
-// Return headers in {key: value} form
-function headersStringToObject (headerString) {
-  var arr = headerString.split('\r\n'), acc = {}, splitIndex, i;
-  for(i = 1; i < arr.length - 2; i++) {
-    splitIndex = arr[i].indexOf(':');
-    acc[arr[i].slice(0, splitIndex)] = arr[i].slice(splitIndex + 2);
+// Return request headers in {key: value} form
+function parseRequestHeaders (headerString) {
+  var arr = headerString.split('\r\n')
+  var acc = []
+  for (var i = 1; i < arr.length - 2; i++) {
+    var splitIndex = arr[i].indexOf(':')
+    var header = {}
+    var key = arr[i].slice(0, splitIndex)
+    var value = arr[i].slice(splitIndex + 2)
+    header[key] = value
+    acc.push(header)
   }
-  return acc;
+  return acc
+}
+
+// Return request headers in {key: value} form
+function parseResponseHeaders (rawHeaders) {
+  var acc = []
+  for (var i = 0; i < rawHeaders.length; i = i + 2) {
+    var header = {}
+    header[rawHeaders[i]] = rawHeaders[i + 1]
+    acc.push(header)
+  }
+  return acc
 }
 
 function Request (options) {
@@ -1236,7 +1252,7 @@ Request.prototype.onRequestResponse = function (response) {
 
   self._reqResInfo.response = {
     statusCode: response.statusCode,
-    headers: response.headers,
+    headers: parseResponseHeaders(response.rawHeaders),
     httpVersion: response.httpVersion
   }
 
@@ -1908,8 +1924,8 @@ Request.prototype.end = function (chunk) {
   }
   if (self.req) {
     self.req.end()
+    self._reqResInfo.request.headers = parseRequestHeaders(self.req._header)
   }
-  self._reqResInfo.request.headers = headersStringToObject(self.req._header);
 }
 Request.prototype.pause = function () {
   var self = this

--- a/tests/test-verbose.js
+++ b/tests/test-verbose.js
@@ -94,6 +94,7 @@ tape('HTTP: redirect(HTTPS) + verbose=true', function (t) {
 
     t.deepEqual(Object.keys(debug[0]), ['request', 'session', 'response', 'timingStart', 'timingStartTimer', 'timings'])
     t.deepEqual(Object.keys(debug[0].request), ['method', 'href', 'headers', 'proxy', 'httpVersion'])
+    t.ok(debug[0].request.headers.Host)
     t.deepEqual(Object.keys(debug[0].session), ['id', 'reused', 'data'])
     t.deepEqual(Object.keys(debug[0].session.data), ['addresses'])
     t.equal(debug[0].session.reused, false)
@@ -101,6 +102,8 @@ tape('HTTP: redirect(HTTPS) + verbose=true', function (t) {
 
     t.deepEqual(Object.keys(debug[1]), ['request', 'session', 'response', 'timingStart', 'timingStartTimer', 'timings'])
     t.deepEqual(Object.keys(debug[1].request), ['method', 'href', 'headers', 'proxy', 'httpVersion'])
+    t.ok(debug[1].request.headers.Host)
+    t.ok(debug[1].request.headers.Referer)
     t.deepEqual(Object.keys(debug[1].session), ['id', 'reused', 'data'])
     t.deepEqual(Object.keys(debug[1].session.data), ['addresses', 'tls'])
     t.deepEqual(Object.keys(debug[1].session.data.tls), ['reused', 'authorized', 'authorizationError', 'cipher', 'protocol', 'ephemeralKeyInfo', 'peerCertificate'])

--- a/tests/test-verbose.js
+++ b/tests/test-verbose.js
@@ -67,13 +67,19 @@ tape('HTTP: verbose=true', function (t) {
     t.equal(typeof res.socket.__SESSION_ID, 'string')
     t.equal(typeof res.socket.__SESSION_DATA, 'object')
     t.deepEqual(Object.keys(debug[0]), ['request', 'session', 'response', 'timingStart', 'timingStartTimer', 'timings'])
-    t.deepEqual(Object.keys(debug[0].request), ['method', 'href', 'proxy', 'httpVersion', 'headers'])
+    t.deepEqual(Object.keys(debug[0].request), ['method', 'href', 'headers', 'proxy', 'httpVersion'])
+
     t.notEqual(debug[0].request.headers.length, 0)
+    t.deepEqual(debug[0].request.headers[0], {key: 'Host', value: 'localhost:' + plainServer.port})
+
     t.deepEqual(Object.keys(debug[0].session), ['id', 'reused', 'data'])
     t.deepEqual(Object.keys(debug[0].session.data), ['addresses'])
     t.equal(debug[0].session.reused, false)
     t.deepEqual(Object.keys(debug[0].response), ['statusCode', 'headers', 'httpVersion'])
+
     t.notEqual(debug[0].response.headers.length, 0)
+    t.equal(debug[0].response.headers[0].key, 'Date')
+    t.ok(debug[0].response.headers[0].value)
 
     t.end()
   })
@@ -95,14 +101,14 @@ tape('HTTP: redirect(HTTPS) + verbose=true', function (t) {
     t.equal(typeof res.socket.__SESSION_DATA, 'object')
 
     t.deepEqual(Object.keys(debug[0]), ['request', 'session', 'response', 'timingStart', 'timingStartTimer', 'timings'])
-    t.deepEqual(Object.keys(debug[0].request), ['method', 'href', 'proxy', 'httpVersion', 'headers'])
+    t.deepEqual(Object.keys(debug[0].request), ['method', 'href', 'headers', 'proxy', 'httpVersion'])
     t.deepEqual(Object.keys(debug[0].session), ['id', 'reused', 'data'])
     t.deepEqual(Object.keys(debug[0].session.data), ['addresses'])
     t.equal(debug[0].session.reused, false)
     t.deepEqual(Object.keys(debug[0].response), ['statusCode', 'headers', 'httpVersion'])
 
     t.deepEqual(Object.keys(debug[1]), ['request', 'session', 'response', 'timingStart', 'timingStartTimer', 'timings'])
-    t.deepEqual(Object.keys(debug[1].request), ['method', 'href', 'proxy', 'httpVersion', 'headers'])
+    t.deepEqual(Object.keys(debug[1].request), ['method', 'href', 'headers', 'proxy', 'httpVersion'])
     t.deepEqual(Object.keys(debug[1].session), ['id', 'reused', 'data'])
     t.deepEqual(Object.keys(debug[1].session.data), ['addresses', 'tls'])
     t.deepEqual(Object.keys(debug[1].session.data.tls), ['reused', 'authorized', 'authorizationError', 'cipher', 'protocol', 'ephemeralKeyInfo', 'peerCertificate'])
@@ -129,7 +135,7 @@ tape('HTTPS: verbose=true', function (t) {
     t.equal(typeof res.socket.__SESSION_ID, 'string')
     t.equal(typeof res.socket.__SESSION_DATA, 'object')
     t.deepEqual(Object.keys(debug[0]), ['request', 'session', 'response', 'timingStart', 'timingStartTimer', 'timings'])
-    t.deepEqual(Object.keys(debug[0].request), ['method', 'href', 'proxy', 'httpVersion', 'headers'])
+    t.deepEqual(Object.keys(debug[0].request), ['method', 'href', 'headers', 'proxy', 'httpVersion'])
     t.deepEqual(Object.keys(debug[0].session), ['id', 'reused', 'data'])
     t.deepEqual(Object.keys(debug[0].session.data), ['addresses', 'tls'])
     t.deepEqual(Object.keys(debug[0].session.data.tls), ['reused', 'authorized', 'authorizationError', 'cipher', 'protocol', 'ephemeralKeyInfo', 'peerCertificate'])
@@ -156,7 +162,7 @@ tape('HTTPS: redirect(HTTP) + verbose=true', function (t) {
     t.equal(typeof res.socket.__SESSION_DATA, 'object')
 
     t.deepEqual(Object.keys(debug[0]), ['request', 'session', 'response', 'timingStart', 'timingStartTimer', 'timings'])
-    t.deepEqual(Object.keys(debug[0].request), ['method', 'href', 'proxy', 'httpVersion', 'headers'])
+    t.deepEqual(Object.keys(debug[0].request), ['method', 'href', 'headers', 'proxy', 'httpVersion'])
     t.deepEqual(Object.keys(debug[0].session), ['id', 'reused', 'data'])
     t.deepEqual(Object.keys(debug[0].session.data), ['addresses', 'tls'])
     t.deepEqual(Object.keys(debug[0].session.data.tls), ['reused', 'authorized', 'authorizationError', 'cipher', 'protocol', 'ephemeralKeyInfo', 'peerCertificate'])
@@ -164,7 +170,7 @@ tape('HTTPS: redirect(HTTP) + verbose=true', function (t) {
     t.deepEqual(Object.keys(debug[0].response), ['statusCode', 'headers', 'httpVersion'])
 
     t.deepEqual(Object.keys(debug[1]), ['request', 'session', 'response', 'timingStart', 'timingStartTimer', 'timings'])
-    t.deepEqual(Object.keys(debug[1].request), ['method', 'href', 'proxy', 'httpVersion', 'headers'])
+    t.deepEqual(Object.keys(debug[1].request), ['method', 'href', 'headers', 'proxy', 'httpVersion'])
     t.deepEqual(Object.keys(debug[1].session), ['id', 'reused', 'data'])
     t.deepEqual(Object.keys(debug[1].session.data), ['addresses'])
     t.equal(debug[1].session.reused, false)

--- a/tests/test-verbose.js
+++ b/tests/test-verbose.js
@@ -68,10 +68,12 @@ tape('HTTP: verbose=true', function (t) {
     t.equal(typeof res.socket.__SESSION_DATA, 'object')
     t.deepEqual(Object.keys(debug[0]), ['request', 'session', 'response', 'timingStart', 'timingStartTimer', 'timings'])
     t.deepEqual(Object.keys(debug[0].request), ['method', 'href', 'proxy', 'httpVersion', 'headers'])
+    t.notEqual(debug[0].request.headers.length, 0)
     t.deepEqual(Object.keys(debug[0].session), ['id', 'reused', 'data'])
     t.deepEqual(Object.keys(debug[0].session.data), ['addresses'])
     t.equal(debug[0].session.reused, false)
     t.deepEqual(Object.keys(debug[0].response), ['statusCode', 'headers', 'httpVersion'])
+    t.notEqual(debug[0].response.headers.length, 0)
 
     t.end()
   })
@@ -94,7 +96,6 @@ tape('HTTP: redirect(HTTPS) + verbose=true', function (t) {
 
     t.deepEqual(Object.keys(debug[0]), ['request', 'session', 'response', 'timingStart', 'timingStartTimer', 'timings'])
     t.deepEqual(Object.keys(debug[0].request), ['method', 'href', 'proxy', 'httpVersion', 'headers'])
-    t.ok(debug[0].request.headers.Host)
     t.deepEqual(Object.keys(debug[0].session), ['id', 'reused', 'data'])
     t.deepEqual(Object.keys(debug[0].session.data), ['addresses'])
     t.equal(debug[0].session.reused, false)
@@ -102,8 +103,6 @@ tape('HTTP: redirect(HTTPS) + verbose=true', function (t) {
 
     t.deepEqual(Object.keys(debug[1]), ['request', 'session', 'response', 'timingStart', 'timingStartTimer', 'timings'])
     t.deepEqual(Object.keys(debug[1].request), ['method', 'href', 'proxy', 'httpVersion', 'headers'])
-    t.ok(debug[1].request.headers.Host)
-    t.ok(debug[1].request.headers.Referer)
     t.deepEqual(Object.keys(debug[1].session), ['id', 'reused', 'data'])
     t.deepEqual(Object.keys(debug[1].session.data), ['addresses', 'tls'])
     t.deepEqual(Object.keys(debug[1].session.data.tls), ['reused', 'authorized', 'authorizationError', 'cipher', 'protocol', 'ephemeralKeyInfo', 'peerCertificate'])

--- a/tests/test-verbose.js
+++ b/tests/test-verbose.js
@@ -67,7 +67,7 @@ tape('HTTP: verbose=true', function (t) {
     t.equal(typeof res.socket.__SESSION_ID, 'string')
     t.equal(typeof res.socket.__SESSION_DATA, 'object')
     t.deepEqual(Object.keys(debug[0]), ['request', 'session', 'response', 'timingStart', 'timingStartTimer', 'timings'])
-    t.deepEqual(Object.keys(debug[0].request), ['method', 'href', 'headers', 'proxy', 'httpVersion'])
+    t.deepEqual(Object.keys(debug[0].request), ['method', 'href', 'proxy', 'httpVersion', 'headers'])
     t.deepEqual(Object.keys(debug[0].session), ['id', 'reused', 'data'])
     t.deepEqual(Object.keys(debug[0].session.data), ['addresses'])
     t.equal(debug[0].session.reused, false)
@@ -93,7 +93,7 @@ tape('HTTP: redirect(HTTPS) + verbose=true', function (t) {
     t.equal(typeof res.socket.__SESSION_DATA, 'object')
 
     t.deepEqual(Object.keys(debug[0]), ['request', 'session', 'response', 'timingStart', 'timingStartTimer', 'timings'])
-    t.deepEqual(Object.keys(debug[0].request), ['method', 'href', 'headers', 'proxy', 'httpVersion'])
+    t.deepEqual(Object.keys(debug[0].request), ['method', 'href', 'proxy', 'httpVersion', 'headers'])
     t.ok(debug[0].request.headers.Host)
     t.deepEqual(Object.keys(debug[0].session), ['id', 'reused', 'data'])
     t.deepEqual(Object.keys(debug[0].session.data), ['addresses'])
@@ -101,7 +101,7 @@ tape('HTTP: redirect(HTTPS) + verbose=true', function (t) {
     t.deepEqual(Object.keys(debug[0].response), ['statusCode', 'headers', 'httpVersion'])
 
     t.deepEqual(Object.keys(debug[1]), ['request', 'session', 'response', 'timingStart', 'timingStartTimer', 'timings'])
-    t.deepEqual(Object.keys(debug[1].request), ['method', 'href', 'headers', 'proxy', 'httpVersion'])
+    t.deepEqual(Object.keys(debug[1].request), ['method', 'href', 'proxy', 'httpVersion', 'headers'])
     t.ok(debug[1].request.headers.Host)
     t.ok(debug[1].request.headers.Referer)
     t.deepEqual(Object.keys(debug[1].session), ['id', 'reused', 'data'])
@@ -130,7 +130,7 @@ tape('HTTPS: verbose=true', function (t) {
     t.equal(typeof res.socket.__SESSION_ID, 'string')
     t.equal(typeof res.socket.__SESSION_DATA, 'object')
     t.deepEqual(Object.keys(debug[0]), ['request', 'session', 'response', 'timingStart', 'timingStartTimer', 'timings'])
-    t.deepEqual(Object.keys(debug[0].request), ['method', 'href', 'headers', 'proxy', 'httpVersion'])
+    t.deepEqual(Object.keys(debug[0].request), ['method', 'href', 'proxy', 'httpVersion', 'headers'])
     t.deepEqual(Object.keys(debug[0].session), ['id', 'reused', 'data'])
     t.deepEqual(Object.keys(debug[0].session.data), ['addresses', 'tls'])
     t.deepEqual(Object.keys(debug[0].session.data.tls), ['reused', 'authorized', 'authorizationError', 'cipher', 'protocol', 'ephemeralKeyInfo', 'peerCertificate'])
@@ -157,7 +157,7 @@ tape('HTTPS: redirect(HTTP) + verbose=true', function (t) {
     t.equal(typeof res.socket.__SESSION_DATA, 'object')
 
     t.deepEqual(Object.keys(debug[0]), ['request', 'session', 'response', 'timingStart', 'timingStartTimer', 'timings'])
-    t.deepEqual(Object.keys(debug[0].request), ['method', 'href', 'headers', 'proxy', 'httpVersion'])
+    t.deepEqual(Object.keys(debug[0].request), ['method', 'href', 'proxy', 'httpVersion', 'headers'])
     t.deepEqual(Object.keys(debug[0].session), ['id', 'reused', 'data'])
     t.deepEqual(Object.keys(debug[0].session.data), ['addresses', 'tls'])
     t.deepEqual(Object.keys(debug[0].session.data.tls), ['reused', 'authorized', 'authorizationError', 'cipher', 'protocol', 'ephemeralKeyInfo', 'peerCertificate'])
@@ -165,7 +165,7 @@ tape('HTTPS: redirect(HTTP) + verbose=true', function (t) {
     t.deepEqual(Object.keys(debug[0].response), ['statusCode', 'headers', 'httpVersion'])
 
     t.deepEqual(Object.keys(debug[1]), ['request', 'session', 'response', 'timingStart', 'timingStartTimer', 'timings'])
-    t.deepEqual(Object.keys(debug[1].request), ['method', 'href', 'headers', 'proxy', 'httpVersion'])
+    t.deepEqual(Object.keys(debug[1].request), ['method', 'href', 'proxy', 'httpVersion', 'headers'])
     t.deepEqual(Object.keys(debug[1].session), ['id', 'reused', 'data'])
     t.deepEqual(Object.keys(debug[1].session.data), ['addresses'])
     t.equal(debug[1].session.reused, false)


### PR DESCRIPTION
## PR Checklist:
- [x] I have run `npm test` locally and all tests are passing.
- [x] I have added/updated tests for any new behavior.
       <!-- Request is a complex project, there are VERY FEW exceptions
               where a new test is not required for new behavior. -->
- [x] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A]
       <!-- If you'd like to suggest a significant change to request,
               please create an issue to discuss those changes and gather
               feedback BEFORE submitting your PR. -->


## PR Description
Bug - Debug object did not have correct request headers.

Cause - Request headers reference was being added to _reqResInfo. The request headers are mutated in onRequestResponse to remove the host header to support subsequent calls for redirects. Similar mutation happens for Referer header. This mutates the debug object also.

Solution - Parsed `ClientRequest._header` for request headers and `IncomingMessage.rawHeaders` for response headers.