### PR TITLE
Added exception handlers when removing listeners from http2 sockets

### DIFF
--- a/lib/http2/request.js
+++ b/lib/http2/request.js
@@ -38,6 +38,11 @@ class Http2Request extends EventEmitter {
   constructor (options) {
     super()
     this.onError = this.onError.bind(this)
+    this.onDrain = this.onDrain.bind(this)
+    this.onClose = this.onClose.bind(this)
+    this.onResponse = this.onResponse.bind(this)
+    this.onEnd = this.onEnd.bind(this)
+
     this.registerListeners = this.registerListeners.bind(this)
     this._flushHeaders = this._flushHeaders.bind(this)
     this[kHeadersFlushed] = false
@@ -92,32 +97,45 @@ class Http2Request extends EventEmitter {
   }
 
   registerListeners () {
-    this.stream.on('drain', () => this.emit('drain', arguments))
-    this.stream.on('error', (e) => this.emit('error', e))
+    this.stream.on('drain', this.onDrain)
+    this.stream.on('error', this.onError)
+    this.stream.on('close', this.onClose)
+    this.stream.on('response', this.onResponse)
+    this.stream.on('end', this.onEnd)
+  }
 
-    this.stream.on('close', (...args) => {
-      if (this.stream.rstCode) {
-        // Emit error message in case of abnormal stream closure
-        this.onError(new Error(`HTTP/2 Stream closed with error code ${rstErrorCodesMap[this.stream.rstCode]}`))
-      }
-
-      this.emit('close', args)
-      this._client.off('error', this.onError)
-      this.stream.removeAllListeners()
-      this.removeAllListeners()
-    })
-
-    this.stream.on('response', (response) => {
-      this.emit('response', new ResponseProxy(response, this.stream))
-    })
-
-    this.stream.on('end', () => {
-      this.emit('end')
-    })
+  onDrain (...args) {
+    this.emit('drain', ...args)
   }
 
   onError (e) {
     this.emit('error', e)
+  }
+
+  onResponse (response) {
+    this.emit('response', new ResponseProxy(response, this.stream))
+  }
+
+  onEnd () {
+    this.emit('end')
+  }
+
+  onClose (...args) {
+    if (this.stream.rstCode) {
+      // Emit error message in case of abnormal stream closure
+      this.onError(new Error(`HTTP/2 Stream closed with error code ${rstErrorCodesMap[this.stream.rstCode]}`))
+    }
+
+    this.emit('close', ...args)
+
+    this._client.off('error', this.onError)
+    this.stream.off('drain', this.onDrain)
+    this.stream.off('error', this.onError)
+    this.stream.off('response', this.onResponse)
+    this.stream.off('end', this.onEnd)
+    this.stream.off('close', this.onClose)
+
+    this.removeAllListeners()
   }
 
   setDefaultEncoding (encoding) {


### PR DESCRIPTION
## PR Checklist:
- [x] I have run `npm test` locally and all tests are passing.
- [x] I have added/updated tests for any new behavior.
       <!-- Request is a complex project, there are VERY FEW exceptions
               where a new test is not required for new behavior. -->
- [ ] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]
       <!-- If you'd like to suggest a significant change to request,
               please create an issue to discuss those changes and gather
               feedback BEFORE submitting your PR. -->


## PR Description
Added try-catch to prevent ERR_HTTP2_SOCKET_UNBOUND from bubbling up. This happens when the main execution tries to remove listeners from the socket, but if the stream has errored out, the socket is disassociated with the session and hence the error.
