### PR TITLE
Added empty CRLF for http2 sent headers to avoid skipping missed headers in debug info

### DIFF
--- a/lib/http2/request.js
+++ b/lib/http2/request.js
@@ -87,7 +87,7 @@ class Http2Request extends EventEmitter {
   }
 
   get _header () {
-    return Object.entries(this.stream.sentHeaders)
+    return '\r\n' + Object.entries(this.stream.sentHeaders)
       .map(([key, value]) => `${key}: ${value}`)
       .join('\r\n') + '\r\n\r\n'
   }


### PR DESCRIPTION
## PR Checklist:
- [x] I have run `npm test` locally and all tests are passing.



## PR Description
Added an empty line with CRLF endings to fix skipping first sent header in http2 requests. 
The bug has no effect on the actual request send, only results in missing headers being recorded in debug info