### PR TITLE
Fix HTTP/2 connection refs causing event loop to not exit

### DIFF
--- a/lib/autohttp/agent.js
+++ b/lib/autohttp/agent.js
@@ -136,13 +136,7 @@ class AutoHttp2Agent extends EventEmitter {
     socket.once('secureConnect', () => {
       socket.removeListener('error', socketConnectionErrorHandler)
 
-      const protocol = socket.alpnProtocol
-
-      if (!protocol) {
-        cb(socket.authorizationError)
-        socket.end()
-        return
-      }
+      const protocol = socket.alpnProtocol || 'http/1.1'
 
       if (!supportedProtocols.includes(protocol)) {
         cb(new Error('Unknown protocol' + protocol))

--- a/lib/http2/agent.js
+++ b/lib/http2/agent.js
@@ -18,7 +18,8 @@ class Http2Agent extends EventEmitter {
     const name = getConnectionName(_options)
     let connection = this.connections[name]
 
-    if (!connection || connection.destroyed || connection.closed) {
+    // Force create a new connection if the connection is destroyed or closed or a new socket object is supplied
+    if (!connection || connection.destroyed || connection.closed || socket) {
       const connectionOptions = {
         ..._options,
         port: _options.port || 443,
@@ -33,6 +34,9 @@ class Http2Agent extends EventEmitter {
       }
 
       connection = http2.connect(uri, connectionOptions)
+      // Connection is created in an unreferenced state and is referenced when a stream is created
+      // This is to prevent the connection from keeping the event loop alive
+      connection.unref()
 
       // Counting semaphore, but since node is single-threaded, this is just a counter
       // Multiple streams can be active on a connection
@@ -77,11 +81,6 @@ class Http2Agent extends EventEmitter {
 
       this.connections[name] = connection
     }
-
-    connection.ref()
-    req.once('close', () => {
-      connection.unref()
-    })
 
     return connection
   }

--- a/lib/http2/request.js
+++ b/lib/http2/request.js
@@ -182,7 +182,16 @@ class Http2Request extends EventEmitter {
         .filter(([key]) => !connectionHeaders.includes(key.toLowerCase()))
     )
 
+    // The client was created in an unreferenced state and is referenced when a stream is created
+    this._client.ref();
     this.stream = this._client.request(this.requestHeaders, {endStream})
+
+    const unreferenceFn = () => {
+      this._client.unref();
+      this.stream.off('close', unreferenceFn);
+    }
+
+    this.stream.on('close', unreferenceFn);
 
     this.registerListeners()
 

--- a/lib/http2/request.js
+++ b/lib/http2/request.js
@@ -183,15 +183,15 @@ class Http2Request extends EventEmitter {
     )
 
     // The client was created in an unreferenced state and is referenced when a stream is created
-    this._client.ref();
+    this._client.ref()
     this.stream = this._client.request(this.requestHeaders, {endStream})
 
     const unreferenceFn = () => {
-      this._client.unref();
-      this.stream.off('close', unreferenceFn);
+      this._client.unref()
+      this.stream.off('close', unreferenceFn)
     }
 
-    this.stream.on('close', unreferenceFn);
+    this.stream.on('close', unreferenceFn)
 
     this.registerListeners()
 


### PR DESCRIPTION
## PR Checklist:
- [x] I have run `npm test` locally and all tests are passing.
- [ ] I have added/updated tests for any new behavior.
       <!-- Request is a complex project, there are VERY FEW exceptions
               where a new test is not required for new behavior. -->
- [ ] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]
       <!-- If you'd like to suggest a significant change to request,
               please create an issue to discuss those changes and gather
               feedback BEFORE submitting your PR. -->


## PR Description
Improves the way refs are handled for HTTP/2 requests. This fixes an issue with multiple parallel `auto` requests  causing the event loop to not exit.
