### PR TITLE
Removing deprecated har-validator library

### DIFF
--- a/lib/har.js
+++ b/lib/har.js
@@ -2,7 +2,6 @@
 
 var fs = require('fs')
 var qs = require('querystring')
-var validate = require('har-validator')
 var extend = require('extend')
 
 function Har (request) {
@@ -131,10 +130,6 @@ Har.prototype.options = function (options) {
   har.bodySize = 0
   har.headersSize = 0
   har.postData.size = 0
-
-  if (!validate.request(har)) {
-    return options
-  }
 
   // clean up and get some utility properties
   var req = this.prep(har)

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "combined-stream": "~1.0.6",
     "extend": "~3.0.2",
     "forever-agent": "~0.6.1",
-    "har-validator": "~5.1.3",
     "http-signature": "~1.3.1",
     "is-typedarray": "~1.0.0",
     "isstream": "~0.1.2",


### PR DESCRIPTION
## PR Checklist:
- [x] I have run `npm test` locally and all tests are passing.
- [N/A] I have added/updated tests for any new behavior.
       <!-- Request is a complex project, there are VERY FEW exceptions
               where a new test is not required for new behavior. -->
- [N/A] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]
       <!-- If you'd like to suggest a significant change to request,
               please create an issue to discuss those changes and gather
               feedback BEFORE submitting your PR. -->


## PR Description
<!-- Describe Your PR Here! -->
This PR removes the use of the har-validator library which is no longer supported. Since the library is EOL, it poses a security concern.