### PR TITLE
Please deprecate beta versions that sort above stable releases due to semver ordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -1313,3 +1313,4 @@ request({url: 'http://www.google.com', jar: j}, function () {
 ```
 
 [back to top](#table-of-contents)
+


### PR DESCRIPTION
The following beta versions are currently published without a `deprecated` flag:

- `2.88.1-postman.8-beta.1`
- `2.88.1-postman.5-beta.1`
- `2.88.1-postman.4-beta.1`
- `2.88.1-postman.3-beta.1`
- `2.88.1-postman.1-beta.1`

## The problem

Due to how semver compares pre-release identifiers, these beta versions sort *higher* than the current stable release (`2.88.1-postman.48`). In semver, alphanumeric identifiers always rank above numeric ones — so `8-beta` is considered greater than `48`. As a result, consumers using a `^` range (e.g. `^2.88.1-postman.31`) have npm silently resolve to a beta version instead of the latest stable.

`2.88.1-postman.8-beta.1` is recording **[80,551 downloads in the last 7 days](https://www.npmjs.com/package/postman-request?activeTab=versions)** on npm

## Why deprecation fixes it

Since npm v6.
```
npm-pick-manifest@2.1.0 included a change that makes it skip deprecated
versions when possible even if they would otherwise be the best semver range
match.
```

When npm install is done. If not then it still installs the 2.88.1-postman.8-beta.1 just with a deprecated warning. 

References:
- [npm deprecate CLI docs](https://docs.npmjs.com/cli/v10/commands/npm-deprecate)
- [Deprecating and undeprecating packages or package versions](https://docs.npmjs.com/deprecating-and-undeprecating-packages-or-package-versions)

## The ask

Could you run the following commands to close out this issue?

```bash
npm deprecate postman-request@2.88.1-postman.8-beta.1 "beta version, use latest stable instead"
npm deprecate postman-request@2.88.1-postman.5-beta.1 "beta version, use latest stable instead"
npm deprecate postman-request@2.88.1-postman.4-beta.1 "beta version, use latest stable instead"
npm deprecate postman-request@2.88.1-postman.3-beta.1 "beta version, use latest stable instead"
npm deprecate postman-request@2.88.1-postman.1-beta.1 "beta version, use latest stable instead"
```

This PR itself contains no meaningful code changes