### PR TITLE
APICLIENT-3136: security: strip Cookie on cross-origin redirect and use full-origin check

### DIFF
--- a/lib/redirect.js
+++ b/lib/redirect.js
@@ -3,6 +3,14 @@
 var fs = require('fs')
 var isUrl = /^https?:/
 
+function defaultPort (protocol) {
+  return protocol === 'https:' ? '443' : '80'
+}
+
+function origin (uri) {
+  return uri.protocol + '//' + uri.hostname + ':' + (uri.port || defaultPort(uri.protocol))
+}
+
 function Redirect (request) {
   this.request = request
   this.followRedirect = true
@@ -132,9 +140,7 @@ Redirect.prototype.onResponse = function (response) {
   // @note: comparing full origin (protocol + hostname + port) so that
   // credentials are not leaked across ports or on a protocol downgrade
   // (e.g. https -> http), not just when the hostname changes.
-  var prevOrigin = uriPrev.protocol + '//' + uriPrev.hostname + (uriPrev.port ? ':' + uriPrev.port : '')
-  var nextOrigin = request.uri.protocol + '//' + request.uri.hostname + (request.uri.port ? ':' + request.uri.port : '')
-  if (request.headers && prevOrigin !== nextOrigin) {
+  if (request.headers && origin(uriPrev) !== origin(request.uri)) {
     request.removeHeader('host')
 
     // remove cookie header, avoid session cookie leak across origins

--- a/lib/redirect.js
+++ b/lib/redirect.js
@@ -123,13 +123,26 @@ Redirect.prototype.onResponse = function (response) {
 
   self.redirects.push({ statusCode: response.statusCode, redirectUri: redirectTo })
 
-  // if the redirect hostname (not just port or protocol) is changed:
+  // if the redirect origin (protocol, hostname or port) is changed:
   //  1. remove host header, the new host will be populated on request.init
-  //  2. remove authorization header, avoid authentication leak
+  //  2. remove cookie header, avoid session leak across origins
+  //  3. remove authorization header, avoid authentication leak
   // @note: This is done because of security reasons, irrespective of the
   // status code or request method used.
-  if (request.headers && uriPrev.hostname !== request.uri.hostname) {
+  // @note: comparing full origin (protocol + hostname + port) so that
+  // credentials are not leaked across ports or on a protocol downgrade
+  // (e.g. https -> http), not just when the hostname changes.
+  var prevOrigin = uriPrev.protocol + '//' + uriPrev.hostname + (uriPrev.port ? ':' + uriPrev.port : '')
+  var nextOrigin = request.uri.protocol + '//' + request.uri.hostname + (request.uri.port ? ':' + request.uri.port : '')
+  if (request.headers && prevOrigin !== nextOrigin) {
     request.removeHeader('host')
+
+    // remove cookie header, avoid session cookie leak across origins
+    request.removeHeader('cookie')
+
+    // clear the cached original cookie header so it isn't re-prepended
+    // to the Cookie header on subsequent hops (see Request.prototype.jar)
+    delete request.originalCookieHeader
 
     // use followAuthorizationHeader option to retain authorization header
     if (!self.followAuthorizationHeader) {

--- a/tests/test-redirect-auth.js
+++ b/tests/test-redirect-auth.js
@@ -5,6 +5,8 @@ var request = require('../index')
 var util = require('util')
 var tape = require('tape')
 var destroyable = require('server-destroy')
+var url = require('url')
+var Redirect = require('../lib/redirect').Redirect
 
 var s = server.createServer()
 var ss = server.createSSLServer()
@@ -80,6 +82,83 @@ function runTest (name, redir, expectAuth) {
   })
 }
 
+function redirectResponse (location) {
+  return {
+    statusCode: 302,
+    caseless: {
+      has: function (header) {
+        return header.toLowerCase() === 'location'
+      },
+      get: function () {
+        return location
+      }
+    },
+    resume: function () {}
+  }
+}
+
+function requestForRedirect (from, to) {
+  var req = {
+    uri: url.parse(from),
+    urlParser: url,
+    headers: {
+      host: 'example.com',
+      authorization: 'Basic abc'
+    },
+    method: 'GET',
+    debug: function () {},
+    removeHeader: function (header) {
+      delete this.headers[header.toLowerCase()]
+    },
+    setHeader: function (header, value) {
+      this.headers[header.toLowerCase()] = value
+    },
+    emit: function () {},
+    init: function () {}
+  }
+
+  var redirect = new Redirect(req)
+  redirect.onResponse(redirectResponse(to))
+  return req
+}
+
+function runPortTest () {
+  tape('redirect to same host different port', function (t) {
+    var from = server.createServer()
+    var to = server.createServer()
+
+    destroyable(from)
+    destroyable(to)
+
+    from.on('/', function (req, res) {
+      res.writeHead(301, {
+        location: to.url + '/'
+      })
+      res.end()
+    })
+
+    to.on('/', function (req, res) {
+      res.end('auth: ' + (req.headers.authorization || '(nothing)'))
+    })
+
+    from.listen(0, function () {
+      to.listen(0, function () {
+        request(from.url, function (err, res, body) {
+          t.equal(err, null)
+          t.equal(res.request.uri.href, to.url + '/')
+          t.equal(res.statusCode, 200)
+          t.equal(body, 'auth: (nothing)')
+          from.destroy(function () {
+            to.destroy(function () {
+              t.end()
+            })
+          })
+        })
+      })
+    })
+  })
+}
+
 function addTests () {
   runTest('same host and protocol',
     redirect.from('http', 'localhost').to('http', 'localhost'),
@@ -87,7 +166,7 @@ function addTests () {
 
   runTest('same host different protocol',
     redirect.from('http', 'localhost').to('https', 'localhost'),
-    true)
+    false)
 
   runTest('different host same protocol',
     redirect.from('https', '127.0.0.1').to('https', 'localhost'),
@@ -96,6 +175,8 @@ function addTests () {
   runTest('different host and protocol',
     redirect.from('http', 'localhost').to('https', '127.0.0.1'),
     false)
+
+  runPortTest()
 }
 
 tape('setup', function (t) {
@@ -127,5 +208,14 @@ tape('redirect URL helper', function (t) {
       src: util.format('https://localhost:%d/to/http/localhost', ss.port),
       dst: util.format('http://localhost:%d/from/https/localhost', s.port)
     })
+  t.end()
+})
+
+tape('redirect preserves authorization when default port is made explicit', function (t) {
+  var httpRequest = requestForRedirect('http://example.com/path', 'http://example.com:80/next')
+  var httpsRequest = requestForRedirect('https://example.com/path', 'https://example.com:443/next')
+
+  t.equal(httpRequest.headers.authorization, 'Basic abc')
+  t.equal(httpsRequest.headers.authorization, 'Basic abc')
   t.end()
 })

--- a/tests/test-redirect-cookie.js
+++ b/tests/test-redirect-cookie.js
@@ -1,0 +1,249 @@
+'use strict'
+
+var tape = require('tape')
+var destroyable = require('server-destroy')
+
+var server = require('./server')
+var request = require('../index')
+var url = require('url')
+var Redirect = require('../lib/redirect').Redirect
+
+function lookupLocalhost (hostname, options, callback) {
+  callback(null, '127.0.0.1', 4)
+}
+
+function redirectResponse (location) {
+  return {
+    statusCode: 302,
+    caseless: {
+      has: function (header) {
+        return header.toLowerCase() === 'location'
+      },
+      get: function () {
+        return location
+      }
+    },
+    resume: function () {}
+  }
+}
+
+function requestForRedirect (from, to) {
+  var req = {
+    uri: url.parse(from),
+    urlParser: url,
+    headers: {
+      host: 'example.com',
+      cookie: 'manual=1'
+    },
+    originalCookieHeader: 'manual=1',
+    method: 'GET',
+    debug: function () {},
+    removeHeader: function (header) {
+      delete this.headers[header.toLowerCase()]
+    },
+    setHeader: function (header, value) {
+      this.headers[header.toLowerCase()] = value
+    },
+    emit: function () {},
+    init: function () {}
+  }
+
+  var redirect = new Redirect(req)
+  redirect.onResponse(redirectResponse(to))
+  return req
+}
+
+function runTest (t, statusCode) {
+  var s = server.createServer()
+  var redirects = 0
+  var cookieHeader = 'manual=1'
+  var jar = request.jar()
+
+  destroyable(s)
+
+  s.on('/', function (req, res) {
+    if (req.headers.host === `${s.redirectHost}:${s.port}`) {
+      res.writeHead(statusCode || 302, {
+        location: `http://${s.respondHost}:${s.port}/`
+      })
+      res.end()
+    } else if (req.headers.host === `${s.respondHost}:${s.port}`) {
+      res.writeHead(200)
+      res.end('cookie: ' + (req.headers.cookie || '(nothing)'))
+    } else {
+      res.writeHead(400)
+      res.end('unknown host')
+    }
+  })
+
+  s.listen(0, function () {
+    s.redirectHost = 'test1.local.omg' // resolves to 127.0.0.1
+    s.respondHost = 'test2.local.omg' // resolves to 127.0.0.1
+
+    jar.setCookieSync('jar=1', `http://${s.redirectHost}:${s.port}/`)
+
+    request({
+      url: `http://${s.redirectHost}:${s.port}/`,
+      headers: {
+        cookie: cookieHeader
+      },
+      jar: jar,
+      followAllRedirects: true,
+      followRedirect: true,
+      lookup: lookupLocalhost
+    }, function (err, res, body) {
+      t.equal(err, null)
+      t.equal(redirects, 1)
+      t.equal(body.toString(), 'cookie: (nothing)')
+      t.equal(res.request.headers.cookie, undefined)
+      s.destroy(function () {
+        t.end()
+      })
+    }).on('redirect', function () {
+      redirects++
+      t.equal(this.response.statusCode, statusCode)
+      t.equal(this.uri.href, `http://${s.respondHost}:${s.port}/`)
+    })
+  })
+}
+
+function runPortTest (t) {
+  var from = server.createServer()
+  var to = server.createServer()
+  var redirects = 0
+  var cookieHeader = 'manual=1'
+
+  destroyable(from)
+  destroyable(to)
+
+  from.on('/', function (req, res) {
+    res.writeHead(302, {
+      location: to.url + '/'
+    })
+    res.end()
+  })
+
+  to.on('/', function (req, res) {
+    res.writeHead(200)
+    res.end('cookie: ' + (req.headers.cookie || '(nothing)'))
+  })
+
+  from.listen(0, function () {
+    to.listen(0, function () {
+      request({
+        url: from.url,
+        headers: {
+          cookie: cookieHeader
+        },
+        followAllRedirects: true,
+        followRedirect: true
+      }, function (err, res, body) {
+        t.equal(err, null)
+        t.equal(redirects, 1)
+        t.equal(res.request.uri.href, to.url + '/')
+        t.equal(body.toString(), 'cookie: (nothing)')
+        t.equal(res.request.headers.cookie, undefined)
+        from.destroy(function () {
+          to.destroy(function () {
+            t.end()
+          })
+        })
+      }).on('redirect', function () {
+        redirects++
+        t.equal(this.response.statusCode, 302)
+        t.equal(this.uri.href, to.url + '/')
+      })
+    })
+  })
+}
+
+function runProtocolTest (t) {
+  var from = server.createServer()
+  var to = server.createSSLServer()
+  var redirects = 0
+  var cookieHeader = 'manual=1'
+
+  destroyable(from)
+  destroyable(to)
+
+  from.on('/', function (req, res) {
+    res.writeHead(302, {
+      location: to.url + '/'
+    })
+    res.end()
+  })
+
+  to.on('/', function (req, res) {
+    res.writeHead(200)
+    res.end('cookie: ' + (req.headers.cookie || '(nothing)'))
+  })
+
+  from.listen(0, function () {
+    to.listen(0, function () {
+      request({
+        url: from.url,
+        headers: {
+          cookie: cookieHeader
+        },
+        followAllRedirects: true,
+        followRedirect: true,
+        rejectUnauthorized: false
+      }, function (err, res, body) {
+        t.equal(err, null)
+        t.equal(redirects, 1)
+        t.equal(res.request.uri.href, to.url + '/')
+        t.equal(body.toString(), 'cookie: (nothing)')
+        t.equal(res.request.headers.cookie, undefined)
+        from.destroy(function () {
+          to.destroy(function () {
+            t.end()
+          })
+        })
+      }).on('redirect', function () {
+        redirects++
+        t.equal(this.response.statusCode, 302)
+        t.equal(this.uri.href, to.url + '/')
+      })
+    })
+  })
+}
+
+tape('301 redirect strips cookie header on cross-origin redirect', function (t) {
+  runTest(t, 301)
+})
+
+tape('302 redirect strips cookie header on cross-origin redirect', function (t) {
+  runTest(t, 302)
+})
+
+tape('303 redirect strips cookie header on cross-origin redirect', function (t) {
+  runTest(t, 303)
+})
+
+tape('307 redirect strips cookie header on cross-origin redirect', function (t) {
+  runTest(t, 307)
+})
+
+tape('308 redirect strips cookie header on cross-origin redirect', function (t) {
+  runTest(t, 308)
+})
+
+tape('redirect strips cookie header when port changes', function (t) {
+  runPortTest(t)
+})
+
+tape('redirect strips cookie header when protocol changes', function (t) {
+  runProtocolTest(t)
+})
+
+tape('redirect preserves cookie header when default port is made explicit', function (t) {
+  var httpRequest = requestForRedirect('http://example.com/path', 'http://example.com:80/next')
+  var httpsRequest = requestForRedirect('https://example.com/path', 'https://example.com:443/next')
+
+  t.equal(httpRequest.headers.cookie, 'manual=1')
+  t.equal(httpRequest.originalCookieHeader, 'manual=1')
+
+  t.equal(httpsRequest.headers.cookie, 'manual=1')
+  t.equal(httpsRequest.originalCookieHeader, 'manual=1')
+  t.end()
+})


### PR DESCRIPTION
## Summary

`lib/redirect.js` stripped the `Authorization` header on a cross-host redirect but **never stripped `Cookie`**, so a session cookie could be leaked to a different host on redirect. The host-change check also compared **hostname only**, ignoring port and scheme, so both `Authorization` and `Cookie` leaked across ports and on an HTTPS to HTTP downgrade.

Same vulnerability class as **undici CVE-2023-45143** (cookie leak on cross-host redirect) and **guzzle CVE-2022-31042** (cross-domain cookie/Authorization leak on redirect).

## Fix

`lib/redirect.js`:
- Broadened the origin check from hostname-only to **full origin** (protocol + hostname + port), so credentials drop on any cross-origin redirect, including port changes and scheme downgrades.
- Strip the `Cookie` header on any cross-origin redirect, alongside the existing `Authorization` removal.
- Clear the cached `originalCookieHeader` on cross-origin redirect so it is not re-prepended to the `Cookie` header on subsequent hops (`Request.prototype.jar` in request.js prepends it to every hop; clearing it here closes that path without duplicating the origin check).

Same-origin redirect behavior is unchanged. `followAuthorizationHeader` still opts back into retaining `Authorization`.

## Risk / behavior change

Cookies and `Authorization` are now also dropped when only the **port** or **scheme** changes across a redirect (previously retained). Intentional and matches corrected security semantics.

## Test plan

- `npx standard lib/redirect.js` — no new warnings/errors (pre-existing no-var style warnings only).
- Manual review: same-origin redirects retain headers; cross-origin (host, port, or scheme change) drop host, cookie, and (unless followAuthorizationHeader) authorization.

Linked Jira: APICLIENT-3136

Generated with [Claude Code](https://claude.com/claude-code)